### PR TITLE
feat(design-system): add cn() class merging utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     "ci": "pnpm lint && pnpm type-check && pnpm test:coverage && pnpm build"
   },
   "dependencies": {
+    "clsx": "2.1.1",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "tailwind-merge": "3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,12 +7,18 @@ settings:
 importers:
   .:
     dependencies:
+      clsx:
+        specifier: 2.1.1
+        version: 2.1.1
       react:
         specifier: ^19.2.4
         version: 19.2.4
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      tailwind-merge:
+        specifier: 3.5.0
+        version: 3.5.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.4
@@ -1334,6 +1340,13 @@ packages:
         integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
       }
     engines: { node: '>=10' }
+
+  clsx@2.1.1:
+    resolution:
+      {
+        integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==,
+      }
+    engines: { node: '>=6' }
 
   color-convert@2.0.1:
     resolution:
@@ -3124,6 +3137,12 @@ packages:
         integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==,
       }
 
+  tailwind-merge@3.5.0:
+    resolution:
+      {
+        integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==,
+      }
+
   tailwindcss@4.2.2:
     resolution:
       {
@@ -4279,6 +4298,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  clsx@2.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -5427,6 +5448,8 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.2: {}
 

--- a/src/shared/utils/cn.test.ts
+++ b/src/shared/utils/cn.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { cn } from './cn';
+
+describe('cn', () => {
+  it('resolves conflicting Tailwind classes by keeping the last one', () => {
+    const result = cn('px-4 bg-primary', 'px-6');
+    expect(result).toBe('bg-primary px-6');
+  });
+
+  it('ignores falsy values (undefined, false, empty string)', () => {
+    const result = cn('text-sm', undefined, false, 'font-bold');
+    expect(result).toBe('text-sm font-bold');
+  });
+
+  it('passes through custom design token classes without stripping them', () => {
+    const result = cn('bg-surface', 'text-foreground', 'shadow-glass');
+    expect(result).toBe('bg-surface text-foreground shadow-glass');
+  });
+
+  it('handles empty string inputs gracefully', () => {
+    const result = cn('', '', 'text-sm');
+    expect(result).toBe('text-sm');
+  });
+
+  it('returns empty string when called with no arguments', () => {
+    const result = cn();
+    expect(result).toBe('');
+  });
+
+  it('merges conditional class objects from clsx', () => {
+    const isActive = true;
+    const isDisabled = false;
+    const result = cn('base-class', {
+      'active-class': isActive,
+      'disabled-class': isDisabled,
+    });
+    expect(result).toBe('base-class active-class');
+  });
+
+  it('resolves complex multi-conflict scenarios', () => {
+    const result = cn(
+      'p-4 text-sm text-foreground rounded-card',
+      'p-6 text-lg',
+    );
+    expect(result).toBe('text-foreground rounded-card p-6 text-lg');
+  });
+});

--- a/src/shared/utils/cn.ts
+++ b/src/shared/utils/cn.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- Create `cn()` utility wrapping `clsx` + `tailwind-merge` for conflict-free Tailwind class composition
- Add `clsx` 2.1.1 and `tailwind-merge` 3.5.0 as pinned dependencies
- 7 unit tests covering conflict resolution, falsy values, custom design tokens, and edge cases

## Test plan
- [x] `pnpm run ci` passes (lint + type-check + test:coverage + build)
- [x] `/project:verify-issue` verdict: PASS — all 4 acceptance criteria + 2 edge cases covered
- [x] `/project:review` verdict: PASS — all 9 categories pass
- [x] 100% test coverage on cn.ts

closes #14