### PR TITLE
feat(button): build Button shared component

### DIFF
--- a/src/shared/components/Button/Button.test.tsx
+++ b/src/shared/components/Button/Button.test.tsx
@@ -1,0 +1,184 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Button } from './Button';
+
+describe('Button', () => {
+  // --- Rendering ---
+
+  it('renders with children text', () => {
+    render(<Button>Click me</Button>);
+    expect(
+      screen.getByRole('button', { name: /click me/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('defaults to type="button" to prevent accidental form submission', () => {
+    render(<Button>Submit</Button>);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
+  it('allows type="submit" to be explicitly set', () => {
+    render(<Button type="submit">Submit</Button>);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+  });
+
+  // --- Variants ---
+
+  it('renders primary variant with gradient classes', () => {
+    render(<Button variant="primary">Primary</Button>);
+    const button = screen.getByRole('button');
+    expect(button.className).toMatch(/from-primary/);
+    expect(button.className).toMatch(/to-primary-container/);
+  });
+
+  it('renders secondary variant with glass classes', () => {
+    render(<Button variant="secondary">Secondary</Button>);
+    const button = screen.getByRole('button');
+    expect(button.className).toMatch(/bg-glass-hover/);
+  });
+
+  it('renders ghost variant with text-only styling', () => {
+    render(<Button variant="ghost">Ghost</Button>);
+    const button = screen.getByRole('button');
+    expect(button.className).toMatch(/text-primary/);
+  });
+
+  it('renders danger variant with danger colors', () => {
+    render(<Button variant="danger">Danger</Button>);
+    const button = screen.getByRole('button');
+    expect(button.className).toMatch(/bg-danger/);
+  });
+
+  // --- Sizes ---
+
+  it('renders sm size with smaller padding and text', () => {
+    render(<Button size="sm">Small</Button>);
+    const button = screen.getByRole('button');
+    expect(button.className).toMatch(/text-xs/);
+  });
+
+  it('renders md size by default', () => {
+    render(<Button>Default</Button>);
+    const button = screen.getByRole('button');
+    expect(button.className).toMatch(/text-sm/);
+  });
+
+  it('renders lg size with larger padding and text', () => {
+    render(<Button size="lg">Large</Button>);
+    const button = screen.getByRole('button');
+    expect(button.className).toMatch(/text-base/);
+  });
+
+  // --- Interaction ---
+
+  it('calls onClick when clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(<Button onClick={handleClick}>Click</Button>);
+
+    await user.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClick when disabled', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <Button disabled onClick={handleClick}>
+        Disabled
+      </Button>,
+    );
+
+    await user.click(screen.getByRole('button'));
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('does not call onClick when loading', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <Button isLoading onClick={handleClick}>
+        Loading
+      </Button>,
+    );
+
+    await user.click(screen.getByRole('button'));
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  // --- Disabled state ---
+
+  it('has disabled attribute and reduced opacity when disabled', () => {
+    render(<Button disabled>Disabled</Button>);
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    expect(button.className).toMatch(/opacity-50/);
+    expect(button.className).toMatch(/cursor-not-allowed/);
+  });
+
+  // --- Loading state ---
+
+  it('shows a loading indicator when isLoading is true', () => {
+    render(<Button isLoading>Loading</Button>);
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    expect(button.querySelector('[aria-label="Loading"]')).toBeInTheDocument();
+  });
+
+  it('hides children text visually when loading', () => {
+    render(<Button isLoading>Loading</Button>);
+    // Children should be invisible but still in DOM for width stability
+    const span = screen.getByText('Loading');
+    expect(span.className).toMatch(/invisible/);
+  });
+
+  // --- className merge ---
+
+  it('merges consumer className with internal classes via cn()', () => {
+    render(<Button className="mt-4">Styled</Button>);
+    const button = screen.getByRole('button');
+    expect(button.className).toMatch(/mt-4/);
+  });
+
+  // --- Icons ---
+
+  it('renders leftIcon before children text', () => {
+    const icon = <svg data-testid="left-icon" aria-hidden="true" />;
+    render(<Button leftIcon={icon}>With Icon</Button>);
+    const button = screen.getByRole('button');
+    const leftIcon = screen.getByTestId('left-icon');
+    expect(button).toContainElement(leftIcon);
+  });
+
+  it('renders rightIcon after children text', () => {
+    const icon = <svg data-testid="right-icon" aria-hidden="true" />;
+    render(<Button rightIcon={icon}>With Icon</Button>);
+    const button = screen.getByRole('button');
+    const rightIcon = screen.getByTestId('right-icon');
+    expect(button).toContainElement(rightIcon);
+  });
+
+  // --- Rest props passthrough ---
+
+  it('passes through data-* and aria-* attributes', () => {
+    render(
+      <Button data-testid="custom" aria-label="Custom action">
+        Action
+      </Button>,
+    );
+    const button = screen.getByTestId('custom');
+    expect(button).toHaveAttribute('aria-label', 'Custom action');
+  });
+
+  // --- Accessibility ---
+
+  it('has visible focus ring styles on the element', () => {
+    render(<Button>Focus me</Button>);
+    // Focus ring is handled by :focus-visible in base.css,
+    // but the button should not suppress outline
+    const button = screen.getByRole('button');
+    expect(button).not.toHaveStyle({ outline: 'none' });
+  });
+});

--- a/src/shared/components/Button/Button.tsx
+++ b/src/shared/components/Button/Button.tsx
@@ -1,0 +1,134 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+import { cn } from '@/shared/utils/cn';
+
+/*
+ * ButtonProps — the component API contract.
+ *
+ * This uses a TypeScript intersection type: we take standard HTML button
+ * attributes (onClick, disabled, type, aria-*, data-*, etc.) and extend
+ * them with our custom props. The `Omit<..., 'disabled'>` removes the
+ * native `disabled` so we can re-declare it alongside `isLoading`
+ * (both disable the button, but for different reasons).
+ */
+type ButtonProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'disabled'> & {
+  /** Visual style variant */
+  variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
+  /** Size scale */
+  size?: 'sm' | 'md' | 'lg';
+  /** Shows loading spinner and disables interaction */
+  isLoading?: boolean;
+  /** Disables the button */
+  disabled?: boolean;
+  /** Icon element rendered before children */
+  leftIcon?: ReactNode;
+  /** Icon element rendered after children */
+  rightIcon?: ReactNode;
+  /** Additional classes merged via cn() */
+  className?: string;
+  /** Button content */
+  children?: ReactNode;
+};
+
+/*
+ * Variant class maps — each variant maps to Tailwind classes
+ * following the Chromatic Refraction design spec.
+ *
+ * Primary: gradient CTA with glow shadow
+ * Secondary: glass-based with ghost border highlight
+ * Ghost: text-only, no background
+ * Danger: solid danger color
+ */
+const variantClasses: Record<NonNullable<ButtonProps['variant']>, string> = {
+  primary:
+    'bg-gradient-to-r from-primary to-primary-container text-primary-foreground shadow-glow-primary glass-edge',
+  secondary:
+    'bg-glass-hover backdrop-blur-md text-foreground glass-edge border border-border',
+  ghost: 'bg-transparent text-primary hover:bg-glass',
+  danger: 'bg-danger text-danger-foreground hover:bg-danger-hover',
+};
+
+const sizeClasses: Record<NonNullable<ButtonProps['size']>, string> = {
+  sm: 'px-3 py-1.5 text-xs gap-1.5',
+  md: 'px-4 py-2 text-sm gap-2',
+  lg: 'px-6 py-3 text-base gap-2.5',
+};
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  isLoading = false,
+  disabled = false,
+  leftIcon,
+  rightIcon,
+  className,
+  children,
+  type = 'button',
+  ...rest
+}: ButtonProps): React.ReactElement {
+  const isDisabled = disabled || isLoading;
+
+  return (
+    <button
+      type={type}
+      disabled={isDisabled}
+      className={cn(
+        // Base styles — shared across all variants
+        'inline-flex items-center justify-center rounded-button font-bold',
+        'transition-all duration-normal',
+        'active:scale-95',
+        // Variant + size
+        variantClasses[variant],
+        sizeClasses[size],
+        // Disabled / loading state
+        isDisabled && 'pointer-events-none opacity-50 cursor-not-allowed',
+        // Consumer overrides
+        className,
+      )}
+      {...rest}
+    >
+      {/* Loading spinner — absolutely positioned over content */}
+      {isLoading ? (
+        <>
+          <span
+            className="absolute inline-flex items-center justify-center"
+            aria-label="Loading"
+          >
+            <svg
+              className="h-4 w-4 animate-spin"
+              viewBox="0 0 24 24"
+              fill="none"
+              aria-hidden="true"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+              />
+            </svg>
+          </span>
+          {/* Keep children in DOM but invisible for width stability */}
+          <span className="invisible flex items-center gap-inherit">
+            {leftIcon}
+            {children}
+            {rightIcon}
+          </span>
+        </>
+      ) : (
+        <>
+          {leftIcon}
+          {children}
+          {rightIcon}
+        </>
+      )}
+    </button>
+  );
+}

--- a/src/shared/components/Button/index.ts
+++ b/src/shared/components/Button/index.ts
@@ -1,0 +1,1 @@
+export { Button } from './Button';


### PR DESCRIPTION
## Summary
- Build Button component with 4 variants (primary gradient, secondary glass, ghost, danger) per Chromatic Refraction design spec
- Support 3 sizes, isLoading/disabled states, leftIcon/rightIcon, className merge via cn()
- 21 unit tests, 100% coverage on Button.tsx

## Test plan
- [x] `pnpm run ci` passes (lint + type-check + test:coverage + build)
- [x] `/project:verify-issue` verdict: PASS — all 8 acceptance criteria + 2 edge cases
- [x] `/project:review` verdict: PASS — all 9 categories
- [x] Accessibility: type="button" default, disabled attribute, loading aria-label, focus-visible ring

closes #17