### PR TITLE
feat(input): build Input shared component

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -9,7 +9,8 @@
   "arrowParens": "always",
   "endOfLine": "lf",
   "plugins": ["@trivago/prettier-plugin-sort-imports"],
-  "importOrder": ["^react", "^@?\\w", "^[./]"],
+  "importOrder": ["^react(.*)$", "^@/(.*)$", "^[./]"],
   "importOrderSeparation": true,
-  "importOrderSortSpecifiers": true
+  "importOrderSortSpecifiers": true,
+  "importOrderParserPlugins": ["typescript", "jsx", "decorators-legacy"]
 }

--- a/src/shared/components/Input/Input.test.tsx
+++ b/src/shared/components/Input/Input.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Input } from './Input';
+
+describe('Input', () => {
+  // --- Label association ---
+
+  it('renders a label associated with the input via htmlFor/id', () => {
+    render(<Input label="Email" id="email-input" />);
+    const input = screen.getByLabelText('Email');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('id', 'email-input');
+  });
+
+  it('auto-generates an id when none is provided', () => {
+    render(<Input label="Username" />);
+    const input = screen.getByLabelText('Username');
+    expect(input).toHaveAttribute('id');
+    expect(input.id).not.toBe('');
+  });
+
+  // --- Helper text ---
+
+  it('displays helper text below the input', () => {
+    render(<Input label="Name" helperText="Enter your full name" />);
+    expect(screen.getByText('Enter your full name')).toBeInTheDocument();
+  });
+
+  // --- Error state ---
+
+  it('displays error message when hasError is true', () => {
+    render(<Input label="Email" hasError errorMessage="Email is required" />);
+    expect(screen.getByText('Email is required')).toBeInTheDocument();
+  });
+
+  it('associates error message with input via aria-describedby', () => {
+    render(
+      <Input
+        label="Email"
+        id="email"
+        hasError
+        errorMessage="Email is required"
+      />,
+    );
+    const input = screen.getByLabelText('Email');
+    expect(input).toHaveAttribute('aria-describedby', 'email-error');
+  });
+
+  it('replaces helper text with error message when hasError', () => {
+    render(
+      <Input
+        label="Email"
+        helperText="We will never share your email"
+        hasError
+        errorMessage="Email is required"
+      />,
+    );
+    expect(screen.getByText('Email is required')).toBeInTheDocument();
+    expect(
+      screen.queryByText('We will never share your email'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('sets aria-invalid when hasError is true', () => {
+    render(<Input label="Email" hasError errorMessage="Required" />);
+    const input = screen.getByLabelText('Email');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  // --- Sizes ---
+
+  it('renders sm size with smaller text', () => {
+    render(<Input label="Small" size="sm" />);
+    const input = screen.getByLabelText('Small');
+    expect(input.className).toMatch(/text-xs/);
+  });
+
+  it('renders md size by default', () => {
+    render(<Input label="Default" />);
+    const input = screen.getByLabelText('Default');
+    expect(input.className).toMatch(/text-sm/);
+  });
+
+  it('renders lg size with larger text', () => {
+    render(<Input label="Large" size="lg" />);
+    const input = screen.getByLabelText('Large');
+    expect(input.className).toMatch(/text-base/);
+  });
+
+  // --- className merge ---
+
+  it('merges consumer className onto the wrapper', () => {
+    const { container } = render(<Input label="Styled" className="mt-4" />);
+    // className applies to the outermost wrapper div
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.className).toMatch(/mt-4/);
+  });
+
+  // --- Rest props passthrough ---
+
+  it('passes placeholder through to the native input', () => {
+    render(<Input label="Search" placeholder="Type to search..." />);
+    expect(
+      screen.getByPlaceholderText('Type to search...'),
+    ).toBeInTheDocument();
+  });
+
+  it('passes type through to the native input', () => {
+    render(<Input label="Password" type="password" />);
+    const input = screen.getByLabelText('Password');
+    expect(input).toHaveAttribute('type', 'password');
+  });
+
+  it('passes autoComplete through to the native input', () => {
+    render(<Input label="Email" autoComplete="email" />);
+    const input = screen.getByLabelText('Email');
+    expect(input).toHaveAttribute('autoComplete', 'email');
+  });
+
+  // --- Disabled state ---
+
+  it('is disabled and has reduced opacity when disabled', () => {
+    render(<Input label="Disabled" disabled />);
+    const input = screen.getByLabelText('Disabled');
+    expect(input).toBeDisabled();
+  });
+
+  // --- Required ---
+
+  it('shows a visual indicator and sets aria-required when required', () => {
+    render(<Input label="Email" required />);
+    const input = screen.getByLabelText(/email/i);
+    expect(input).toHaveAttribute('aria-required', 'true');
+    // Visual indicator — asterisk in the label
+    expect(screen.getByText('*')).toBeInTheDocument();
+  });
+
+  // --- Interaction ---
+
+  it('calls onChange when the user types', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<Input label="Name" onChange={handleChange} />);
+
+    await user.type(screen.getByLabelText('Name'), 'hello');
+    expect(handleChange).toHaveBeenCalledTimes(5); // one per character
+  });
+});

--- a/src/shared/components/Input/Input.tsx
+++ b/src/shared/components/Input/Input.tsx
@@ -1,0 +1,123 @@
+import type { InputHTMLAttributes } from 'react';
+import { useId } from 'react';
+
+import { cn } from '@/shared/utils/cn';
+
+/*
+ * InputProps — extends native input attributes with label, error, helper text.
+ *
+ * useId() hook: React 18+ provides useId() to generate stable, unique IDs
+ * for accessibility associations (htmlFor/id, aria-describedby). This avoids
+ * the common pitfall of manually generating IDs that collide in SSR or
+ * concurrent mode. In Go terms, it's like a context-scoped UUID generator.
+ *
+ * The `size` prop conflicts with the native HTML `size` attribute (which sets
+ * the visible character width). We Omit it and redeclare with our own scale.
+ */
+type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> & {
+  /** Label text displayed above the input */
+  label: string;
+  /** Helper text displayed below the input */
+  helperText?: string;
+  /** Whether the input is in an error state */
+  hasError?: boolean;
+  /** Error message displayed when hasError is true */
+  errorMessage?: string;
+  /** Size scale */
+  size?: 'sm' | 'md' | 'lg';
+  /** Additional classes on the outer wrapper */
+  className?: string;
+};
+
+const sizeClasses: Record<NonNullable<InputProps['size']>, string> = {
+  sm: 'px-3 py-1.5 text-xs',
+  md: 'px-4 py-2.5 text-sm',
+  lg: 'px-4 py-3 text-base',
+};
+
+export function Input({
+  label,
+  helperText,
+  hasError = false,
+  errorMessage,
+  size = 'md',
+  className,
+  id: externalId,
+  disabled,
+  required,
+  ...rest
+}: InputProps): React.ReactElement {
+  /*
+   * useId() generates a unique ID per component instance.
+   * We prefer the externally provided id, falling back to the generated one.
+   * This ensures label association works even when consumers don't pass an id.
+   */
+  const generatedId = useId();
+  const inputId = externalId ?? generatedId;
+  const errorId = `${inputId}-error`;
+  const helperId = `${inputId}-helper`;
+
+  const showError = hasError && errorMessage;
+  const showHelper = !showError && helperText;
+
+  return (
+    <div className={cn('flex flex-col gap-1.5', className)}>
+      {/* Label */}
+      <label
+        htmlFor={inputId}
+        className={cn(
+          'text-xs font-bold uppercase tracking-[0.05em]',
+          hasError ? 'text-danger' : 'text-foreground-muted',
+        )}
+      >
+        {label}
+        {required ? (
+          <span className="ml-0.5 text-danger" aria-hidden="true">
+            *
+          </span>
+        ) : null}
+      </label>
+
+      {/* Input */}
+      <input
+        id={inputId}
+        disabled={disabled}
+        required={required}
+        aria-required={required ? 'true' : undefined}
+        aria-invalid={hasError ? 'true' : undefined}
+        aria-describedby={
+          showError ? errorId : showHelper ? helperId : undefined
+        }
+        className={cn(
+          // Base styles — Chromatic Refraction spec
+          'w-full rounded-input bg-surface-high text-foreground',
+          'placeholder:text-foreground-subtle',
+          'outline-none transition-all duration-normal',
+          // Focus glow — tertiary cyan at 30% opacity
+          'focus:ring-1 focus:ring-tertiary/30',
+          // Error state — danger ring
+          hasError && 'ring-1 ring-danger/30 bg-danger-muted',
+          // Disabled
+          disabled && 'opacity-50 cursor-not-allowed',
+          // Size
+          sizeClasses[size],
+        )}
+        {...rest}
+      />
+
+      {/* Error message */}
+      {showError ? (
+        <p id={errorId} className="text-xs text-danger" role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
+
+      {/* Helper text */}
+      {showHelper ? (
+        <p id={helperId} className="text-xs text-foreground-subtle">
+          {helperText}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/shared/components/Input/index.ts
+++ b/src/shared/components/Input/index.ts
@@ -1,0 +1,1 @@
+export { Input } from './Input';


### PR DESCRIPTION
## Summary
- Build Input component with label, helper text, error state, sizes, disabled/required support
- Auto-generate id via useId() for label association when not provided
- Error messages associated via aria-describedby with role="alert"
- Fix Prettier import order config (react before @/ paths)
- 17 unit tests, 100% coverage

## Test plan
- [x] `pnpm run ci` passes (lint + type-check + test:coverage + build)
- [x] `/project:verify-issue` verdict: PASS — all 8 acceptance criteria + 3 edge cases
- [x] `/project:review` verdict: PASS — all 9 categories
- [x] Accessibility: htmlFor/id, aria-describedby, aria-invalid, aria-required, role="alert", focus ring

closes #18