### PR TITLE
feat(card): build Card shared component

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -81,6 +81,14 @@ export default tseslint.config(
             'sibling',
             'index',
           ],
+          pathGroups: [
+            {
+              pattern: '@/**',
+              group: 'internal',
+              position: 'before',
+            },
+          ],
+          pathGroupsExcludedImportTypes: ['builtin'],
           'newlines-between': 'always',
           alphabetize: { order: 'asc', caseInsensitive: true },
         },

--- a/src/shared/components/Card/Card.test.tsx
+++ b/src/shared/components/Card/Card.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Card } from './Card';
+
+describe('Card', () => {
+  // --- Rendering ---
+
+  it('renders with children content', () => {
+    render(<Card>Card content</Card>);
+    expect(screen.getByText('Card content')).toBeInTheDocument();
+  });
+
+  it('renders as an empty container without breaking', () => {
+    const { container } = render(<Card />);
+    expect(container.firstElementChild).toBeInTheDocument();
+  });
+
+  // --- Variants ---
+
+  it('renders default (glass) variant with glass styling', () => {
+    const { container } = render(<Card>Glass</Card>);
+    const card = container.firstElementChild;
+    expect(card?.className).toMatch(/bg-glass/);
+    expect(card?.className).toMatch(/glass-edge/);
+  });
+
+  it('renders outlined variant with surface-high background', () => {
+    const { container } = render(<Card variant="outlined">Outlined</Card>);
+    const card = container.firstElementChild;
+    expect(card?.className).toMatch(/bg-surface-high/);
+  });
+
+  // --- Subcomponents ---
+
+  it('renders Card.Header in the correct position', () => {
+    render(
+      <Card>
+        <Card.Header>Header Content</Card.Header>
+      </Card>,
+    );
+    expect(screen.getByText('Header Content')).toBeInTheDocument();
+  });
+
+  it('renders Card.Body in the correct position', () => {
+    render(
+      <Card>
+        <Card.Body>Body Content</Card.Body>
+      </Card>,
+    );
+    expect(screen.getByText('Body Content')).toBeInTheDocument();
+  });
+
+  it('renders Card.Footer in the correct position', () => {
+    render(
+      <Card>
+        <Card.Footer>Footer Content</Card.Footer>
+      </Card>,
+    );
+    expect(screen.getByText('Footer Content')).toBeInTheDocument();
+  });
+
+  it('renders all three subcomponents together', () => {
+    render(
+      <Card>
+        <Card.Header>Header</Card.Header>
+        <Card.Body>Body</Card.Body>
+        <Card.Footer>Footer</Card.Footer>
+      </Card>,
+    );
+    expect(screen.getByText('Header')).toBeInTheDocument();
+    expect(screen.getByText('Body')).toBeInTheDocument();
+    expect(screen.getByText('Footer')).toBeInTheDocument();
+  });
+
+  it('renders cleanly with only Card.Body (no header/footer)', () => {
+    const { container } = render(
+      <Card>
+        <Card.Body>Just body</Card.Body>
+      </Card>,
+    );
+    expect(screen.getByText('Just body')).toBeInTheDocument();
+    // Should only have 1 child div (the body)
+    const card = container.firstElementChild;
+    expect(card?.children).toHaveLength(1);
+  });
+
+  // --- Footer alignment ---
+
+  it('right-aligns Card.Footer content by default', () => {
+    render(
+      <Card>
+        <Card.Footer>Actions</Card.Footer>
+      </Card>,
+    );
+    const footer = screen.getByText('Actions');
+    expect(footer.className).toMatch(/justify-end/);
+  });
+
+  // --- className merge ---
+
+  it('merges className on the Card wrapper', () => {
+    const { container } = render(<Card className="mt-8">Styled</Card>);
+    expect(container.firstElementChild?.className).toMatch(/mt-8/);
+  });
+
+  it('merges className on Card.Header', () => {
+    render(
+      <Card>
+        <Card.Header className="pb-0">Header</Card.Header>
+      </Card>,
+    );
+    expect(screen.getByText('Header').className).toMatch(/pb-0/);
+  });
+
+  it('merges className on Card.Body', () => {
+    render(
+      <Card>
+        <Card.Body className="gap-4">Body</Card.Body>
+      </Card>,
+    );
+    expect(screen.getByText('Body').className).toMatch(/gap-4/);
+  });
+
+  it('merges className on Card.Footer', () => {
+    render(
+      <Card>
+        <Card.Footer className="border-t">Footer</Card.Footer>
+      </Card>,
+    );
+    expect(screen.getByText('Footer').className).toMatch(/border-t/);
+  });
+
+  // --- Rest props passthrough ---
+
+  it('passes through data-* and aria-* on Card', () => {
+    render(
+      <Card data-testid="dashboard-card" aria-label="Account summary">
+        Content
+      </Card>,
+    );
+    const card = screen.getByTestId('dashboard-card');
+    expect(card).toHaveAttribute('aria-label', 'Account summary');
+  });
+});

--- a/src/shared/components/Card/Card.tsx
+++ b/src/shared/components/Card/Card.tsx
@@ -1,0 +1,63 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
+import { cn } from '@/shared/utils/cn';
+
+import { CardBody } from './CardBody';
+import { CardFooter } from './CardFooter';
+import { CardHeader } from './CardHeader';
+
+/*
+ * Card — a compositional container with dot-notation subcomponents.
+ *
+ * Usage:
+ *   <Card>
+ *     <Card.Header>Title</Card.Header>
+ *     <Card.Body>Content</Card.Body>
+ *     <Card.Footer>Actions</Card.Footer>
+ *   </Card>
+ *
+ * Subcomponents are in separate files to satisfy react-refresh
+ * (Fast Refresh requires one component per file for HMR tracking).
+ * The Object.assign pattern attaches them as Card.Header etc.
+ */
+
+type CardProps = HTMLAttributes<HTMLDivElement> & {
+  /** Visual variant */
+  variant?: 'default' | 'outlined';
+  /** Additional classes merged via cn() */
+  className?: string;
+  children?: ReactNode;
+};
+
+const variantClasses: Record<NonNullable<CardProps['variant']>, string> = {
+  default:
+    'bg-glass backdrop-blur-[var(--blur-glass)] border border-border glass-edge shadow-glass',
+  outlined: 'bg-surface-high border border-border',
+};
+
+// eslint-disable-next-line react-refresh/only-export-components -- compound component: CardRoot is exported via Object.assign
+function CardRoot({
+  variant = 'default',
+  className,
+  children,
+  ...rest
+}: CardProps): React.ReactElement {
+  return (
+    <div
+      className={cn(
+        'rounded-card overflow-hidden',
+        variantClasses[variant],
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const Card = Object.assign(CardRoot, {
+  Header: CardHeader,
+  Body: CardBody,
+  Footer: CardFooter,
+});

--- a/src/shared/components/Card/CardBody.tsx
+++ b/src/shared/components/Card/CardBody.tsx
@@ -1,0 +1,20 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
+import { cn } from '@/shared/utils/cn';
+
+type CardBodyProps = HTMLAttributes<HTMLDivElement> & {
+  className?: string;
+  children?: ReactNode;
+};
+
+export function CardBody({
+  className,
+  children,
+  ...rest
+}: CardBodyProps): React.ReactElement {
+  return (
+    <div className={cn('px-8 py-6', className)} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/src/shared/components/Card/CardFooter.tsx
+++ b/src/shared/components/Card/CardFooter.tsx
@@ -1,0 +1,23 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
+import { cn } from '@/shared/utils/cn';
+
+type CardFooterProps = HTMLAttributes<HTMLDivElement> & {
+  className?: string;
+  children?: ReactNode;
+};
+
+export function CardFooter({
+  className,
+  children,
+  ...rest
+}: CardFooterProps): React.ReactElement {
+  return (
+    <div
+      className={cn('flex items-center justify-end px-8 pb-8 pt-0', className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/shared/components/Card/CardHeader.tsx
+++ b/src/shared/components/Card/CardHeader.tsx
@@ -1,0 +1,20 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
+import { cn } from '@/shared/utils/cn';
+
+type CardHeaderProps = HTMLAttributes<HTMLDivElement> & {
+  className?: string;
+  children?: ReactNode;
+};
+
+export function CardHeader({
+  className,
+  children,
+  ...rest
+}: CardHeaderProps): React.ReactElement {
+  return (
+    <div className={cn('px-8 pt-8 pb-0', className)} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/src/shared/components/Card/index.ts
+++ b/src/shared/components/Card/index.ts
@@ -1,0 +1,1 @@
+export { Card } from './Card';


### PR DESCRIPTION
## Summary
- Build Card with default (glass) and outlined variants, compositional subcomponents (Card.Header/Body/Footer)
- Split subcomponents into separate files for react-refresh HMR compatibility
- Footer right-aligns by default, all slots support className merge
- Fix ESLint import/order pathGroups for @/ alias
- 15 unit tests, 100% coverage

## Test plan
- [x] `pnpm run ci` passes
- [x] `/project:verify-issue` verdict: PASS — all 6 ACs + 2 edge cases
- [x] `/project:review` verdict: PASS — all 9 categories

closes #20