### PR TITLE
feat(modal): build Modal shared component

### DIFF
--- a/src/shared/components/Modal/Modal.test.tsx
+++ b/src/shared/components/Modal/Modal.test.tsx
@@ -1,0 +1,250 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Modal } from './Modal';
+
+describe('Modal', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    title: 'Test Modal',
+  };
+
+  // --- Portal rendering ---
+
+  it('renders via a portal at the document body', () => {
+    const { baseElement } = render(
+      <div data-testid="parent">
+        <Modal {...defaultProps}>
+          <p>Modal content</p>
+        </Modal>
+      </div>,
+    );
+    // Modal should be in the body, not inside the parent div
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    const parent = baseElement.querySelector('[data-testid="parent"]');
+    expect(parent).not.toContainElement(dialog);
+  });
+
+  it('does not render when isOpen is false', () => {
+    render(
+      <Modal {...defaultProps} isOpen={false}>
+        <p>Hidden</p>
+      </Modal>,
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  // --- Focus management ---
+
+  it('moves focus to the first focusable element when opened', async () => {
+    render(
+      <Modal {...defaultProps}>
+        <button type="button">First button</button>
+        <button type="button">Second button</button>
+      </Modal>,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /first button/i }),
+      ).toHaveFocus();
+    });
+  });
+
+  it('focuses the close button when no other focusable children exist', async () => {
+    render(
+      <Modal {...defaultProps}>
+        <p>No focusable children here</p>
+      </Modal>,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /close/i })).toHaveFocus();
+    });
+  });
+
+  // --- Focus trapping ---
+
+  it('traps focus: Tab from last element wraps to first', async () => {
+    const user = userEvent.setup();
+    render(
+      <Modal {...defaultProps}>
+        <button type="button">First</button>
+        <button type="button">Last</button>
+      </Modal>,
+    );
+    // Wait for initial focus
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /first/i })).toHaveFocus();
+    });
+    // Tab to Last, then to Close (last focusable), then Tab should wrap to First
+    await user.tab(); // → Last
+    await user.tab(); // → Close button
+    await user.tab(); // → wraps to First
+    expect(screen.getByRole('button', { name: /first/i })).toHaveFocus();
+  });
+
+  it('traps focus: Shift+Tab from first element wraps to last', async () => {
+    const user = userEvent.setup();
+    render(
+      <Modal {...defaultProps}>
+        <button type="button">First</button>
+        <button type="button">Last</button>
+      </Modal>,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /first/i })).toHaveFocus();
+    });
+    // Shift+Tab from first should wrap to Close button (last focusable)
+    await user.tab({ shift: true });
+    expect(screen.getByRole('button', { name: /close/i })).toHaveFocus();
+  });
+
+  // --- Escape key ---
+
+  it('calls onClose when Escape is pressed', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Modal {...defaultProps} onClose={onClose}>
+        <p>Content</p>
+      </Modal>,
+    );
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // --- Backdrop click ---
+
+  it('calls onClose when the backdrop is clicked', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Modal {...defaultProps} onClose={onClose}>
+        <p>Content</p>
+      </Modal>,
+    );
+    // Click the backdrop (the overlay div behind the dialog)
+    const backdrop = screen.getByRole('dialog').parentElement;
+    if (backdrop) {
+      await user.click(backdrop);
+    }
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClose when clicking inside the dialog', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Modal {...defaultProps} onClose={onClose}>
+        <p>Click me</p>
+      </Modal>,
+    );
+    await user.click(screen.getByText('Click me'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  // --- Body scroll lock ---
+
+  it('prevents body scroll when open', () => {
+    render(
+      <Modal {...defaultProps}>
+        <p>Content</p>
+      </Modal>,
+    );
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('restores body scroll when closed', () => {
+    const { unmount } = render(
+      <Modal {...defaultProps}>
+        <p>Content</p>
+      </Modal>,
+    );
+    unmount();
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  // --- ARIA attributes ---
+
+  it('has role="dialog" and aria-modal="true"', () => {
+    render(
+      <Modal {...defaultProps}>
+        <p>Content</p>
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('announces title via aria-labelledby', () => {
+    render(
+      <Modal {...defaultProps}>
+        <p>Content</p>
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-labelledby');
+    const labelId = dialog.getAttribute('aria-labelledby');
+    const titleEl = document.getElementById(labelId ?? '');
+    expect(titleEl?.textContent).toBe('Test Modal');
+  });
+
+  it('announces description via aria-describedby when provided', () => {
+    render(
+      <Modal {...defaultProps} description="This is a description">
+        <p>Content</p>
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-describedby');
+    const descId = dialog.getAttribute('aria-describedby');
+    const descEl = document.getElementById(descId ?? '');
+    expect(descEl?.textContent).toBe('This is a description');
+  });
+
+  // --- className merge ---
+
+  it('merges className onto the dialog panel', () => {
+    render(
+      <Modal {...defaultProps} className="max-w-2xl">
+        <p>Content</p>
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.className).toMatch(/max-w-2xl/);
+  });
+
+  // --- Sizes ---
+
+  it('renders sm size with narrow width', () => {
+    render(
+      <Modal {...defaultProps} size="sm">
+        <p>Content</p>
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.className).toMatch(/max-w-sm/);
+  });
+
+  it('renders md size by default', () => {
+    render(
+      <Modal {...defaultProps}>
+        <p>Content</p>
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.className).toMatch(/max-w-lg/);
+  });
+
+  it('renders lg size with wide width', () => {
+    render(
+      <Modal {...defaultProps} size="lg">
+        <p>Content</p>
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.className).toMatch(/max-w-2xl/);
+  });
+});

--- a/src/shared/components/Modal/Modal.tsx
+++ b/src/shared/components/Modal/Modal.tsx
@@ -1,0 +1,238 @@
+import type { ReactNode } from 'react';
+import { useCallback, useEffect, useId, useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+import { cn } from '@/shared/utils/cn';
+
+/*
+ * Modal — an accessible dialog rendered via portal.
+ *
+ * Key React concepts at play:
+ *
+ * createPortal: Renders children into a DOM node outside the parent tree.
+ * In Go terms, it's like writing to a different io.Writer — the component
+ * lives in the React tree for state/context, but its DOM output goes
+ * somewhere else (document.body). This escapes parent overflow:hidden.
+ *
+ * Focus trapping: We query all focusable elements inside the dialog and
+ * intercept Tab/Shift+Tab to cycle within them. This is critical for
+ * accessibility — keyboard users must not be able to Tab behind the modal.
+ *
+ * useCallback: We wrap the keydown handler in useCallback so the same
+ * function reference is used for addEventListener/removeEventListener.
+ * Without this, cleanup would fail and we'd leak event listeners.
+ */
+
+interface ModalProps {
+  /** Whether the modal is visible */
+  isOpen: boolean;
+  /** Called when the modal should close (Escape, backdrop click, close button) */
+  onClose: () => void;
+  /** Dialog title — announced to screen readers via aria-labelledby */
+  title: string;
+  /** Optional description — announced via aria-describedby */
+  description?: string;
+  /** Size scale controlling max-width */
+  size?: 'sm' | 'md' | 'lg';
+  /** Additional classes on the dialog panel */
+  className?: string;
+  /** Dialog content */
+  children?: ReactNode;
+}
+
+const sizeClasses: Record<NonNullable<ModalProps['size']>, string> = {
+  sm: 'max-w-sm',
+  md: 'max-w-lg',
+  lg: 'max-w-2xl',
+};
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function Modal({
+  isOpen,
+  onClose,
+  title,
+  description,
+  size = 'md',
+  className,
+  children,
+}: ModalProps): React.ReactElement | null {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+  const descriptionId = useId();
+
+  /*
+   * Focus management: when the modal opens, move focus to the first
+   * focusable element. If none exist, focus the close button (which
+   * is always present). This runs on every isOpen change.
+   */
+  useEffect(() => {
+    if (!isOpen) return;
+
+    // Small delay to let the portal render into the DOM
+    const timer = setTimeout(() => {
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+
+      const focusableElements = dialog.querySelectorAll(FOCUSABLE_SELECTOR);
+      const firstFocusable = focusableElements[0];
+
+      if (firstFocusable instanceof HTMLElement) {
+        firstFocusable.focus();
+      }
+    }, 0);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [isOpen]);
+
+  /*
+   * Body scroll lock: prevent the page from scrolling behind the modal.
+   * Save the original overflow value and restore it on cleanup.
+   */
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [isOpen]);
+
+  /*
+   * Keyboard handler: Escape closes, Tab traps focus inside.
+   *
+   * useCallback ensures stable reference for add/removeEventListener.
+   * The dependency array includes onClose — if the parent passes a new
+   * onClose function, we rebind. This is safe because the effect below
+   * handles cleanup.
+   */
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+        return;
+      }
+
+      // Focus trapping on Tab
+      if (event.key === 'Tab') {
+        const dialog = dialogRef.current;
+        if (!dialog) return;
+
+        const focusableElements = dialog.querySelectorAll(FOCUSABLE_SELECTOR);
+        if (focusableElements.length === 0) return;
+
+        const firstElement = focusableElements[0] as HTMLElement;
+        const lastElement = focusableElements[
+          focusableElements.length - 1
+        ] as HTMLElement;
+
+        if (event.shiftKey) {
+          // Shift+Tab: if on first element, wrap to last
+          if (document.activeElement === firstElement) {
+            event.preventDefault();
+            lastElement.focus();
+          }
+        } else {
+          // Tab: if on last element, wrap to first
+          if (document.activeElement === lastElement) {
+            event.preventDefault();
+            firstElement.focus();
+          }
+        }
+      }
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, handleKeyDown]);
+
+  /*
+   * Backdrop click handler: close when clicking the overlay
+   * but not when clicking inside the dialog panel.
+   */
+  const handleBackdropClick = useCallback(
+    (event: React.MouseEvent) => {
+      // Only close if the click target is the backdrop itself
+      if (event.target === event.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    // Backdrop overlay
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      onClick={handleBackdropClick}
+      role="presentation"
+    >
+      {/* Dialog panel */}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={description ? descriptionId : undefined}
+        className={cn(
+          'relative w-full rounded-modal border border-border bg-surface-mid p-8 shadow-glass-lg glass-edge',
+          sizeClasses[size],
+          className,
+        )}
+      >
+        {/* Title */}
+        <h2 id={titleId} className="pr-8 text-xl font-bold text-foreground">
+          {title}
+        </h2>
+
+        {/* Description */}
+        {description ? (
+          <p id={descriptionId} className="mt-2 text-sm text-foreground-muted">
+            {description}
+          </p>
+        ) : null}
+
+        {/* Content — placed before close button so content gets focus first */}
+        <div className="mt-6">{children}</div>
+
+        {/* Close button — last in DOM for focus order, visually positioned top-right */}
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-4 top-4 rounded-pill p-1.5 text-foreground-muted transition-colors duration-normal hover:bg-glass-hover hover:text-foreground"
+          aria-label="Close"
+        >
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/shared/components/Modal/index.ts
+++ b/src/shared/components/Modal/index.ts
@@ -1,0 +1,1 @@
+export { Modal } from './Modal';


### PR DESCRIPTION
## Summary
- Build Modal with portal rendering, focus trapping, Escape/backdrop close, body scroll lock
- Full ARIA support: role="dialog", aria-modal, aria-labelledby, aria-describedby
- 3 sizes (sm, md, lg), className merge, close button with focus fallback
- 18 unit tests, 94% statement / 84% branch coverage (uncovered: defensive null guards)

## Test plan
- [x] `pnpm run ci` passes
- [x] `/project:verify-issue` verdict: PASS — all 9 ACs + 3 edge cases
- [x] `/project:review` verdict: PASS — all 9 categories
- [x] Accessibility: focus trap, escape key, aria-modal, aria-labelledby/describedby, close button

closes #21