### PR TITLE
feat(spinner): build Spinner shared component

### DIFF
--- a/src/shared/components/Spinner/Spinner.test.tsx
+++ b/src/shared/components/Spinner/Spinner.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Spinner } from './Spinner';
+
+describe('Spinner', () => {
+  // --- Rendering ---
+
+  it('renders an SVG with animation', () => {
+    const { container } = render(<Spinner />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg?.getAttribute('class')).toMatch(/animate-spin/);
+  });
+
+  // --- Sizes ---
+
+  it('renders sm size', () => {
+    const { container } = render(<Spinner size="sm" />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('class')).toMatch(/h-4/);
+    expect(svg?.getAttribute('class')).toMatch(/w-4/);
+  });
+
+  it('renders md size by default', () => {
+    const { container } = render(<Spinner />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('class')).toMatch(/h-5/);
+    expect(svg?.getAttribute('class')).toMatch(/w-5/);
+  });
+
+  it('renders lg size', () => {
+    const { container } = render(<Spinner size="lg" />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('class')).toMatch(/h-8/);
+    expect(svg?.getAttribute('class')).toMatch(/w-8/);
+  });
+
+  // --- Color inheritance ---
+
+  it('uses currentColor so it adapts to parent text color', () => {
+    const { container } = render(<Spinner />);
+    const circle = container.querySelector('circle');
+    expect(circle).toHaveAttribute('stroke', 'currentColor');
+  });
+
+  // --- Accessibility ---
+
+  it('has role="status" for screen readers', () => {
+    render(<Spinner />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('has a default aria-label of "Loading"', () => {
+    render(<Spinner />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Loading');
+  });
+
+  it('accepts a custom aria-label', () => {
+    render(<Spinner aria-label="Saving changes" />);
+    expect(screen.getByRole('status')).toHaveAttribute(
+      'aria-label',
+      'Saving changes',
+    );
+  });
+
+  // --- className merge ---
+
+  it('merges consumer className via cn()', () => {
+    const { container } = render(<Spinner className="text-primary" />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('class')).toMatch(/text-primary/);
+  });
+
+  // --- Layout stability ---
+
+  it('does not cause layout shift (has explicit dimensions)', () => {
+    const { container } = render(<Spinner />);
+    const svg = container.querySelector('svg');
+    // shrink-0 prevents flex collapsing
+    expect(svg?.getAttribute('class')).toMatch(/shrink-0/);
+  });
+});

--- a/src/shared/components/Spinner/Spinner.tsx
+++ b/src/shared/components/Spinner/Spinner.tsx
@@ -1,0 +1,67 @@
+import type { SVGAttributes } from 'react';
+
+import { cn } from '@/shared/utils/cn';
+
+/*
+ * Spinner — an animated loading indicator.
+ *
+ * Uses CSS `animate-spin` for rotation — no JS animation libraries.
+ * Color inherits from parent via `currentColor` on the stroke, so
+ * a Spinner inside a Button automatically matches the button's text color.
+ *
+ * Reduced motion: base.css has a global `prefers-reduced-motion: reduce`
+ * rule that sets animation-duration to 0.01ms. No per-component handling needed.
+ *
+ * The SVG is two overlapping circles:
+ * 1. A full circle at 25% opacity (the "track")
+ * 2. A quarter-arc at 75% opacity (the spinning indicator)
+ */
+
+type SpinnerProps = Omit<SVGAttributes<SVGSVGElement>, 'children'> & {
+  /** Size scale */
+  size?: 'sm' | 'md' | 'lg';
+  /** Additional classes merged via cn() */
+  className?: string;
+  /** Screen reader label (default: "Loading") */
+  'aria-label'?: string;
+};
+
+const sizeClasses: Record<NonNullable<SpinnerProps['size']>, string> = {
+  sm: 'h-4 w-4',
+  md: 'h-5 w-5',
+  lg: 'h-8 w-8',
+};
+
+export function Spinner({
+  size = 'md',
+  className,
+  'aria-label': ariaLabel = 'Loading',
+  ...rest
+}: SpinnerProps): React.ReactElement {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      role="status"
+      aria-label={ariaLabel}
+      className={cn('shrink-0 animate-spin', sizeClasses[size], className)}
+      {...rest}
+    >
+      {/* Track circle — faint background ring */}
+      <circle
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+        className="opacity-25"
+      />
+      {/* Spinning arc — the visible indicator */}
+      <path
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+        className="opacity-75"
+      />
+    </svg>
+  );
+}

--- a/src/shared/components/Spinner/index.ts
+++ b/src/shared/components/Spinner/index.ts
@@ -1,0 +1,1 @@
+export { Spinner } from './Spinner';


### PR DESCRIPTION
## Summary
- Build Spinner with CSS animate-spin, 3 sizes, currentColor inheritance
- role="status" + aria-label for screen readers, reduced motion via base.css
- 10 unit tests, 100% coverage

## Test plan
- [x] `pnpm run ci` passes
- [x] `/project:verify-issue` verdict: PASS — all 6 ACs + 2 edge cases
- [x] `/project:review` verdict: PASS — all 9 categories
- [x] Accessibility: role="status", aria-label, reduced motion support

closes #24