### PR TITLE
feat(layout): build app layout with sidebar and content area

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,28 +4,25 @@ import { DashboardPage } from '@/pages/DashboardPage';
 import { HouseholdsPage } from '@/pages/HouseholdsPage';
 import { NotFoundPage } from '@/pages/NotFoundPage';
 import { SettingsPage } from '@/pages/SettingsPage';
+import { AppLayout } from '@/shared/components/AppLayout';
 
 /*
- * App — the route configuration (composition root for routing).
+ * App — route configuration with layout wrapper.
  *
- * React Router v7 uses <Routes> and <Route> for declarative routing.
- * Each <Route> maps a URL path to a component. When the URL matches,
- * that component renders — no full page reload.
- *
- * <Navigate> on "/" redirects to /dashboard so the root URL has content.
- * The "*" catch-all route handles 404s.
- *
- * The BrowserRouter wrapper lives in main.tsx — App just defines routes.
- * This separation lets tests use MemoryRouter instead of BrowserRouter.
+ * The AppLayout route has no `path` — it wraps all child routes.
+ * Its <Outlet> renders whichever child route matches.
+ * This is React Router's "layout route" pattern.
  */
 function App(): React.ReactElement {
   return (
     <Routes>
-      <Route path="/" element={<Navigate to="/dashboard" replace />} />
-      <Route path="/dashboard" element={<DashboardPage />} />
-      <Route path="/households" element={<HouseholdsPage />} />
-      <Route path="/settings" element={<SettingsPage />} />
-      <Route path="*" element={<NotFoundPage />} />
+      <Route element={<AppLayout />}>
+        <Route path="/" element={<Navigate to="/dashboard" replace />} />
+        <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/households" element={<HouseholdsPage />} />
+        <Route path="/settings" element={<SettingsPage />} />
+        <Route path="*" element={<NotFoundPage />} />
+      </Route>
     </Routes>
   );
 }

--- a/src/shared/components/AppLayout/AppLayout.test.tsx
+++ b/src/shared/components/AppLayout/AppLayout.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { AppLayout } from './AppLayout';
+
+function renderWithRouter(ui?: React.ReactElement) {
+  return render(
+    <MemoryRouter initialEntries={['/']}>
+      <Routes>
+        <Route element={<AppLayout />}>
+          <Route
+            path="/"
+            element={ui ?? <div data-testid="page-content">Page Content</div>}
+          />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('AppLayout', () => {
+  // --- Structure ---
+
+  it('renders a sidebar and main content area', () => {
+    renderWithRouter();
+    expect(
+      screen.getByRole('complementary', { name: /sidebar/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+
+  it('renders child route content via Outlet', () => {
+    renderWithRouter();
+    expect(screen.getByTestId('page-content')).toBeInTheDocument();
+  });
+
+  // --- Desktop (sidebar visible by default) ---
+
+  it('shows sidebar on desktop by default', () => {
+    renderWithRouter();
+    const sidebar = screen.getByRole('complementary', { name: /sidebar/i });
+    // On desktop the sidebar is visible (not hidden)
+    expect(sidebar).toBeVisible();
+  });
+
+  // --- Mobile toggle ---
+
+  it('has a menu button for mobile sidebar toggle', () => {
+    renderWithRouter();
+    expect(screen.getByRole('button', { name: /menu/i })).toBeInTheDocument();
+  });
+
+  it('toggles sidebar visibility when menu button is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithRouter();
+    const menuButton = screen.getByRole('button', { name: /menu/i });
+
+    // Click to open
+    await user.click(menuButton);
+    // The mobile overlay should appear
+    expect(
+      screen.getByRole('complementary', { name: /sidebar/i }),
+    ).toBeVisible();
+  });
+
+  it('closes mobile sidebar when Escape is pressed', async () => {
+    const user = userEvent.setup();
+    renderWithRouter();
+
+    // Open sidebar
+    await user.click(screen.getByRole('button', { name: /menu/i }));
+
+    // Press Escape
+    await user.keyboard('{Escape}');
+    // Sidebar overlay should be hidden (isMobileOpen = false)
+    // The sidebar element still exists but the overlay is gone
+    expect(screen.queryByRole('presentation')).not.toBeInTheDocument();
+  });
+
+  it('closes mobile sidebar when clicking the backdrop overlay', async () => {
+    const user = userEvent.setup();
+    renderWithRouter();
+
+    // Open sidebar
+    await user.click(screen.getByRole('button', { name: /menu/i }));
+
+    // Click the backdrop
+    const overlay = screen.getByRole('presentation');
+    await user.click(overlay);
+    expect(screen.queryByRole('presentation')).not.toBeInTheDocument();
+  });
+
+  // --- Content area ---
+
+  it('renders content area with consistent padding', () => {
+    renderWithRouter();
+    const main = screen.getByRole('main');
+    expect(main.className).toMatch(/p-/);
+  });
+
+  // --- Design tokens ---
+
+  it('uses design tokens for sidebar styling (glass, border, blur)', () => {
+    renderWithRouter();
+    const sidebar = screen.getByRole('complementary', { name: /sidebar/i });
+    expect(sidebar.className).toMatch(/bg-glass/);
+    expect(sidebar.className).toMatch(/glass-edge/);
+  });
+
+  // --- Overflow ---
+
+  it('sidebar scrolls independently with overflow-y-auto', () => {
+    renderWithRouter();
+    const sidebar = screen.getByRole('complementary', { name: /sidebar/i });
+    expect(sidebar.className).toMatch(/overflow-y-auto/);
+  });
+});

--- a/src/shared/components/AppLayout/AppLayout.tsx
+++ b/src/shared/components/AppLayout/AppLayout.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Outlet } from 'react-router';
+
+import { Icon } from '@/shared/components/Icon';
+import { Text } from '@/shared/components/Text';
+import { cn } from '@/shared/utils/cn';
+
+/*
+ * AppLayout — the app shell with sidebar + content area.
+ *
+ * Uses React Router's <Outlet> to render child routes in the content area.
+ * The sidebar is a floating glass pill on desktop (per Chromatic Refraction spec)
+ * and a slide-over overlay on mobile.
+ *
+ * useState for sidebar toggle: This is local UI state — it only affects
+ * this component's rendering. In Go terms, it's like a mutex-protected
+ * boolean flag that controls which code path runs on the next render.
+ *
+ * useCallback for handlers: The Escape key handler and backdrop click
+ * handler are wrapped in useCallback so the event listener cleanup
+ * works correctly (same function reference for add/remove).
+ */
+
+export function AppLayout(): React.ReactElement {
+  const [isMobileOpen, setIsMobileOpen] = useState(false);
+
+  const closeMobile = useCallback(() => {
+    setIsMobileOpen(false);
+  }, []);
+
+  // Escape key closes mobile sidebar
+  useEffect(() => {
+    if (!isMobileOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        closeMobile();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isMobileOpen, closeMobile]);
+
+  return (
+    <div className="bg-mesh min-h-screen font-sans antialiased tracking-tight">
+      {/* Mobile menu button — visible only on small screens */}
+      <button
+        type="button"
+        onClick={() => {
+          setIsMobileOpen(true);
+        }}
+        className="fixed left-4 top-4 z-50 flex h-10 w-10 items-center justify-center rounded-pill bg-glass text-foreground-muted backdrop-blur-[var(--blur-glass)] glass-edge lg:hidden"
+        aria-label="Open menu"
+      >
+        <Icon name="menu" size="md" />
+      </button>
+
+      {/* Mobile backdrop overlay */}
+      {isMobileOpen ? (
+        <div
+          className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm lg:hidden"
+          role="presentation"
+          onClick={closeMobile}
+        />
+      ) : null}
+
+      {/* Sidebar — floating glass pill */}
+      <aside
+        aria-label="Sidebar"
+        className={cn(
+          // Base styles (always present)
+          'fixed bottom-4 left-4 top-4 z-50 flex w-64 flex-col overflow-y-auto rounded-card border border-border bg-glass py-8 shadow-glass backdrop-blur-[var(--blur-glass-lg)] glass-edge',
+          // Desktop: always visible
+          'hidden lg:flex',
+          // Mobile: shown when open
+          isMobileOpen && 'flex',
+        )}
+      >
+        {/* App branding */}
+        <div className="px-6 pb-6">
+          <Text variant="h4" className="tracking-tighter">
+            Luminous Ledger
+          </Text>
+          <Text variant="label" className="mt-1 opacity-70">
+            The Digital Curator
+          </Text>
+        </div>
+
+        {/* Navigation slot — will be filled by SidebarNav in #27 */}
+        <nav className="flex-1 px-2" aria-label="Main navigation">
+          {/* Placeholder for navigation items */}
+        </nav>
+      </aside>
+
+      {/* Main content area */}
+      <main
+        className={cn(
+          'min-h-screen p-6',
+          // Desktop: offset by sidebar width + gaps
+          'lg:pl-[calc(16rem+2rem)]',
+        )}
+      >
+        <div className="mx-auto max-w-[1400px]">
+          <Outlet />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/shared/components/AppLayout/index.ts
+++ b/src/shared/components/AppLayout/index.ts
@@ -1,0 +1,1 @@
+export { AppLayout } from './AppLayout';


### PR DESCRIPTION
## Summary
- Build AppLayout shell: floating glass sidebar + main content area with Outlet
- Responsive: sidebar visible on desktop, toggleable overlay on mobile
- Mobile sidebar closes on Escape and backdrop click
- 10 unit tests, coverage passes thresholds

## Test plan
- [x] `pnpm run ci` passes
- [x] `/project:verify-issue` verdict: PASS — all 6 ACs + 3 edge cases
- [x] `/project:review` verdict: PASS — all 9 categories
- [x] Accessibility: aria-label on sidebar/toggle/nav, Escape key, role=presentation backdrop

closes #26