### PR TITLE
feat(layout): build PageHeader and PageContent components

### DIFF
--- a/src/shared/components/PageContent/PageContent.test.tsx
+++ b/src/shared/components/PageContent/PageContent.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { PageContent } from './PageContent';
+
+describe('PageContent', () => {
+  it('renders children content', () => {
+    render(<PageContent>Page body content</PageContent>);
+    expect(screen.getByText('Page body content')).toBeInTheDocument();
+  });
+
+  it('renders as an empty container without breaking', () => {
+    const { container } = render(<PageContent />);
+    expect(container.firstElementChild).toBeInTheDocument();
+  });
+
+  it('merges className via cn()', () => {
+    const { container } = render(
+      <PageContent className="gap-8">Content</PageContent>,
+    );
+    expect(container.firstElementChild?.className).toMatch(/gap-8/);
+  });
+
+  it('provides consistent spacing between header and content', () => {
+    const { container } = render(<PageContent>Content</PageContent>);
+    // Should have top margin/padding for spacing from PageHeader
+    expect(container.firstElementChild?.className).toMatch(/mt-/);
+  });
+});

--- a/src/shared/components/PageContent/PageContent.tsx
+++ b/src/shared/components/PageContent/PageContent.tsx
@@ -1,0 +1,21 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
+import { cn } from '@/shared/utils/cn';
+
+type PageContentProps = HTMLAttributes<HTMLDivElement> & {
+  /** Additional classes merged via cn() */
+  className?: string;
+  children?: ReactNode;
+};
+
+export function PageContent({
+  className,
+  children,
+  ...rest
+}: PageContentProps): React.ReactElement {
+  return (
+    <div className={cn('mt-8', className)} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/src/shared/components/PageContent/index.ts
+++ b/src/shared/components/PageContent/index.ts
@@ -1,0 +1,1 @@
+export { PageContent } from './PageContent';

--- a/src/shared/components/PageHeader/PageHeader.test.tsx
+++ b/src/shared/components/PageHeader/PageHeader.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { PageHeader } from './PageHeader';
+
+describe('PageHeader', () => {
+  it('renders the title as a heading', () => {
+    render(<PageHeader title="Dashboard" />);
+    expect(
+      screen.getByRole('heading', { name: /dashboard/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the title with display typography', () => {
+    render(<PageHeader title="Dashboard" />);
+    const heading = screen.getByRole('heading', { name: /dashboard/i });
+    expect(heading.className).toMatch(/text-5xl/);
+    expect(heading.className).toMatch(/font-black/);
+  });
+
+  it('renders subtitle when provided', () => {
+    render(<PageHeader title="Dashboard" subtitle="Your financial overview" />);
+    expect(screen.getByText('Your financial overview')).toBeInTheDocument();
+  });
+
+  it('renders subtitle in secondary style', () => {
+    render(<PageHeader title="Dashboard" subtitle="Your financial overview" />);
+    const subtitle = screen.getByText('Your financial overview');
+    expect(subtitle.className).toMatch(/text-foreground-muted/);
+  });
+
+  it('does not render subtitle element when not provided', () => {
+    const { container } = render(<PageHeader title="Dashboard" />);
+    // Only the heading should be present, no subtitle p tag
+    const paragraphs = container.querySelectorAll('p');
+    expect(paragraphs).toHaveLength(0);
+  });
+
+  it('renders actions slot right-aligned', () => {
+    render(
+      <PageHeader title="Dashboard">
+        <button type="button">Export</button>
+      </PageHeader>,
+    );
+    expect(screen.getByRole('button', { name: /export/i })).toBeInTheDocument();
+  });
+
+  it('merges className via cn()', () => {
+    const { container } = render(
+      <PageHeader title="Dashboard" className="mb-12" />,
+    );
+    expect(container.firstElementChild?.className).toMatch(/mb-12/);
+  });
+
+  it('handles very long titles gracefully', () => {
+    render(
+      <PageHeader title="This is a very long page title that might need to wrap on smaller screens" />,
+    );
+    const heading = screen.getByRole('heading');
+    // Should not have truncate — wrapping is preferred for headings
+    expect(heading).toBeInTheDocument();
+  });
+});

--- a/src/shared/components/PageHeader/PageHeader.tsx
+++ b/src/shared/components/PageHeader/PageHeader.tsx
@@ -1,0 +1,45 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
+import { Text } from '@/shared/components/Text';
+import { cn } from '@/shared/utils/cn';
+
+type PageHeaderProps = HTMLAttributes<HTMLElement> & {
+  /** Page title — rendered as a display heading */
+  title: string;
+  /** Optional subtitle — rendered below the title in muted style */
+  subtitle?: string;
+  /** Additional classes merged via cn() */
+  className?: string;
+  /** Action buttons — rendered right-aligned in the header */
+  children?: ReactNode;
+};
+
+export function PageHeader({
+  title,
+  subtitle,
+  className,
+  children,
+  ...rest
+}: PageHeaderProps): React.ReactElement {
+  return (
+    <header
+      className={cn(
+        'flex flex-col gap-4 md:flex-row md:items-end md:justify-between',
+        className,
+      )}
+      {...rest}
+    >
+      <div>
+        <Text variant="h1">{title}</Text>
+        {subtitle ? (
+          <Text variant="bodySmall" className="mt-2 text-foreground-muted">
+            {subtitle}
+          </Text>
+        ) : null}
+      </div>
+      {children ? (
+        <div className="flex items-center gap-3">{children}</div>
+      ) : null}
+    </header>
+  );
+}

--- a/src/shared/components/PageHeader/index.ts
+++ b/src/shared/components/PageHeader/index.ts
@@ -1,0 +1,1 @@
+export { PageHeader } from './PageHeader';


### PR DESCRIPTION
## Summary
- Build PageHeader with title, subtitle, right-aligned actions slot
- Build PageContent with consistent spacing from header
- Responsive: stacks on mobile, inline on desktop
- 12 unit tests, 100% coverage

## Test plan
- [x] `pnpm run ci` passes
- [x] `/project:verify-issue` verdict: PASS — all 6 ACs + 2 edge cases
- [x] `/project:review` verdict: PASS — all 9 categories

closes #28