### PR TITLE
feat(error-boundary): add feature-level error boundaries

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,22 +5,44 @@ import { HouseholdsPage } from '@/pages/HouseholdsPage';
 import { NotFoundPage } from '@/pages/NotFoundPage';
 import { SettingsPage } from '@/pages/SettingsPage';
 import { AppLayout } from '@/shared/components/AppLayout';
+import { ErrorBoundary } from '@/shared/components/ErrorBoundary';
 
 /*
- * App — route configuration with layout wrapper.
+ * App — route configuration with layout wrapper and error boundaries.
  *
- * The AppLayout route has no `path` — it wraps all child routes.
- * Its <Outlet> renders whichever child route matches.
- * This is React Router's "layout route" pattern.
+ * Each feature route is wrapped in its own ErrorBoundary so a crash
+ * in one feature (e.g., Households) doesn't take down the sidebar
+ * or other features. The layout shell remains functional.
  */
 function App(): React.ReactElement {
   return (
     <Routes>
       <Route element={<AppLayout />}>
         <Route path="/" element={<Navigate to="/dashboard" replace />} />
-        <Route path="/dashboard" element={<DashboardPage />} />
-        <Route path="/households" element={<HouseholdsPage />} />
-        <Route path="/settings" element={<SettingsPage />} />
+        <Route
+          path="/dashboard"
+          element={
+            <ErrorBoundary>
+              <DashboardPage />
+            </ErrorBoundary>
+          }
+        />
+        <Route
+          path="/households"
+          element={
+            <ErrorBoundary>
+              <HouseholdsPage />
+            </ErrorBoundary>
+          }
+        />
+        <Route
+          path="/settings"
+          element={
+            <ErrorBoundary>
+              <SettingsPage />
+            </ErrorBoundary>
+          }
+        />
         <Route path="*" element={<NotFoundPage />} />
       </Route>
     </Routes>

--- a/src/shared/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/shared/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ErrorBoundary } from './ErrorBoundary';
+
+// A component that throws during render — used to trigger the error boundary
+function ThrowingComponent({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error('Test render error');
+  }
+  return <div>Normal content</div>;
+}
+
+// Suppress React's console.error for expected error boundary triggers
+const originalConsoleError = console.error;
+function suppressReactErrorLogs(): void {
+  console.error = (...args: unknown[]) => {
+    const msg = typeof args[0] === 'string' ? args[0] : '';
+    if (
+      msg.includes('Error: Uncaught') ||
+      msg.includes('The above error occurred') ||
+      msg.includes('Error Boundary')
+    ) {
+      return;
+    }
+    originalConsoleError(...args);
+  };
+}
+
+function restoreConsoleError(): void {
+  console.error = originalConsoleError;
+}
+
+describe('ErrorBoundary', () => {
+  // --- Normal rendering ---
+
+  it('renders children when no error occurs', () => {
+    render(
+      <ErrorBoundary>
+        <div>Safe content</div>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Safe content')).toBeInTheDocument();
+  });
+
+  // --- Error catching ---
+
+  it('displays fallback UI when a child throws during render', () => {
+    suppressReactErrorLogs();
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow />
+      </ErrorBoundary>,
+    );
+    restoreConsoleError();
+
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+  });
+
+  it('shows a "Try again" button in the fallback', () => {
+    suppressReactErrorLogs();
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow />
+      </ErrorBoundary>,
+    );
+    restoreConsoleError();
+
+    expect(
+      screen.getByRole('button', { name: /try again/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('uses Typography and Button from the design system in fallback', () => {
+    suppressReactErrorLogs();
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow />
+      </ErrorBoundary>,
+    );
+    restoreConsoleError();
+
+    // Heading should use design system typography classes
+    const heading = screen.getByText(/something went wrong/i);
+    expect(heading).toBeInTheDocument();
+
+    // Button should be present
+    const button = screen.getByRole('button', { name: /try again/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  // --- Recovery ---
+
+  it('resets and re-renders children when "Try again" is clicked', async () => {
+    suppressReactErrorLogs();
+    const user = userEvent.setup();
+
+    let shouldThrow = true;
+    function ConditionalThrower() {
+      if (shouldThrow) {
+        throw new Error('Conditional error');
+      }
+      return <div>Recovered content</div>;
+    }
+
+    render(
+      <ErrorBoundary>
+        <ConditionalThrower />
+      </ErrorBoundary>,
+    );
+    restoreConsoleError();
+
+    // Should show fallback
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+
+    // Fix the error condition
+    shouldThrow = false;
+
+    // Click try again
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+
+    // Should recover
+    expect(screen.getByText('Recovered content')).toBeInTheDocument();
+  });
+
+  // --- Isolation ---
+
+  it('does not affect sibling components when an error occurs', () => {
+    suppressReactErrorLogs();
+    render(
+      <div>
+        <div data-testid="sibling">Sibling is fine</div>
+        <ErrorBoundary>
+          <ThrowingComponent shouldThrow />
+        </ErrorBoundary>
+      </div>,
+    );
+    restoreConsoleError();
+
+    // Sibling should still be rendered
+    expect(screen.getByTestId('sibling')).toBeInTheDocument();
+    // Error boundary shows fallback
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+  });
+
+  // --- Custom onError callback ---
+
+  it('calls onError callback when an error is caught', () => {
+    suppressReactErrorLogs();
+    const onError = vi.fn();
+
+    render(
+      <ErrorBoundary onError={onError}>
+        <ThrowingComponent shouldThrow />
+      </ErrorBoundary>,
+    );
+    restoreConsoleError();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Test render error' }),
+      expect.objectContaining({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expect.any() returns any by design
+        componentStack: expect.any(String),
+      }),
+    );
+  });
+});

--- a/src/shared/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/shared/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,85 @@
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+
+import { Button } from '@/shared/components/Button';
+import { Text } from '@/shared/components/Text';
+
+/*
+ * ErrorBoundary — catches render errors in child components.
+ *
+ * This is the ONE place where a class component is required in React.
+ * Error boundaries use getDerivedStateFromError (synchronous, during render)
+ * and componentDidCatch (asynchronous, for logging). There is no hooks
+ * equivalent — React deliberately requires class components for this.
+ *
+ * In Go terms, this is like a deferred recover() that catches panics
+ * in the render tree. Without it, a single error crashes the entire app.
+ *
+ * IMPORTANT LIMITATION: Error boundaries do NOT catch:
+ * - Errors in event handlers (use try/catch in the handler)
+ * - Errors in async code (promises, setTimeout)
+ * - Server-side rendering errors
+ * - Errors thrown in the error boundary itself
+ */
+
+interface ErrorBoundaryProps {
+  /** Child components to protect */
+  children: ReactNode;
+  /** Optional callback when an error is caught (for future error reporting) */
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  /*
+   * getDerivedStateFromError runs during the render phase.
+   * It receives the thrown error and returns new state.
+   * This is synchronous — it must return immediately.
+   */
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  /*
+   * componentDidCatch runs after the error has been committed to the DOM.
+   * This is where you log errors or call reporting services.
+   * The errorInfo includes the component stack trace.
+   */
+  override componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    this.props.onError?.(error, errorInfo);
+  }
+
+  private readonly handleReset = (): void => {
+    this.setState({ hasError: false });
+  };
+
+  override render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-[40vh] flex-col items-center justify-center text-center">
+          <Text variant="h3">Something went wrong</Text>
+          <Text variant="bodySmall" className="mt-2 max-w-md">
+            An unexpected error occurred in this section. The rest of the
+            application is still functional.
+          </Text>
+          <Button variant="primary" className="mt-6" onClick={this.handleReset}>
+            Try again
+          </Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/shared/components/ErrorBoundary/index.ts
+++ b/src/shared/components/ErrorBoundary/index.ts
@@ -1,0 +1,1 @@
+export { ErrorBoundary } from './ErrorBoundary';


### PR DESCRIPTION
## Summary
- Add ErrorBoundary class component with fallback UI and "Try again" reset
- Wrap each feature route in its own boundary for error isolation
- onError callback for future Sentry/reporting integration
- 7 unit tests covering catch, recovery, isolation, and callback

## Test plan
- [x] `pnpm run ci` passes
- [x] `/project:verify-issue` verdict: PASS — all 5 ACs + 2 edge cases
- [x] `/project:review` verdict: PASS — all 9 categories
- [x] Sidebar remains functional when a feature crashes

closes #30