### PR TITLE
feat(storybook): add stories for Button and Input

### DIFF
--- a/src/shared/components/Button/Button.stories.tsx
+++ b/src/shared/components/Button/Button.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
+import { Icon } from '@/shared/components/Icon';
+
 import { Button } from './Button';
 
 const meta = {
@@ -17,15 +19,105 @@ const meta = {
     },
     isLoading: { control: 'boolean' },
     disabled: { control: 'boolean' },
+    children: { control: 'text' },
+  },
+  args: {
+    children: 'Button',
+    variant: 'primary',
+    size: 'md',
   },
 } satisfies Meta<typeof Button>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// --- Default ---
+
+export const Default: Story = {};
+
+// --- Variants ---
+
 export const Primary: Story = {
+  args: { variant: 'primary', children: 'Primary' },
+};
+
+export const Secondary: Story = {
+  args: { variant: 'secondary', children: 'Secondary' },
+};
+
+export const Ghost: Story = {
+  args: { variant: 'ghost', children: 'Ghost' },
+};
+
+export const Danger: Story = {
+  args: { variant: 'danger', children: 'Danger' },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-4">
+      <Button variant="primary">Primary</Button>
+      <Button variant="secondary">Secondary</Button>
+      <Button variant="ghost">Ghost</Button>
+      <Button variant="danger">Danger</Button>
+    </div>
+  ),
+};
+
+// --- Sizes ---
+
+export const Small: Story = {
+  args: { size: 'sm', children: 'Small' },
+};
+
+export const Medium: Story = {
+  args: { size: 'md', children: 'Medium' },
+};
+
+export const Large: Story = {
+  args: { size: 'lg', children: 'Large' },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Button size="sm">Small</Button>
+      <Button size="md">Medium</Button>
+      <Button size="lg">Large</Button>
+    </div>
+  ),
+};
+
+// --- With Icons ---
+
+export const WithLeftIcon: Story = {
   args: {
-    children: 'Primary Button',
-    variant: 'primary',
+    children: 'Add Transaction',
+    leftIcon: <Icon name="plus" size="sm" />,
   },
+};
+
+export const WithRightIcon: Story = {
+  args: {
+    children: 'Next',
+    rightIcon: <Icon name="chevron-right" size="sm" />,
+  },
+};
+
+export const WithBothIcons: Story = {
+  args: {
+    children: 'Transfer',
+    leftIcon: <Icon name="send" size="sm" />,
+    rightIcon: <Icon name="arrow-right" size="sm" />,
+  },
+};
+
+// --- States ---
+
+export const Loading: Story = {
+  args: { isLoading: true, children: 'Saving...' },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true, children: 'Disabled' },
 };

--- a/src/shared/components/Input/Input.stories.tsx
+++ b/src/shared/components/Input/Input.stories.tsx
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Input } from './Input';
+
+const meta = {
+  title: 'Components/Input',
+  component: Input,
+  tags: ['autodocs'],
+  argTypes: {
+    label: { control: 'text' },
+    helperText: { control: 'text' },
+    hasError: { control: 'boolean' },
+    errorMessage: { control: 'text' },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+    disabled: { control: 'boolean' },
+    required: { control: 'boolean' },
+    placeholder: { control: 'text' },
+    type: {
+      control: 'select',
+      options: ['text', 'email', 'password', 'number'],
+    },
+  },
+  args: {
+    label: 'Email',
+    placeholder: 'Enter your email...',
+    size: 'md',
+  },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// --- Default ---
+
+export const Default: Story = {};
+
+// --- With Helper Text ---
+
+export const WithHelperText: Story = {
+  args: {
+    label: 'Password',
+    type: 'password',
+    placeholder: 'Enter password...',
+    helperText: 'Must be at least 8 characters',
+  },
+};
+
+// --- With Error ---
+
+export const WithError: Story = {
+  args: {
+    label: 'Email',
+    placeholder: 'Enter your email...',
+    hasError: true,
+    errorMessage: 'Please enter a valid email address',
+  },
+};
+
+export const ErrorReplacesHelper: Story = {
+  args: {
+    label: 'Username',
+    placeholder: 'Choose a username...',
+    helperText: 'Letters and numbers only',
+    hasError: true,
+    errorMessage: 'Username is already taken',
+  },
+};
+
+// --- Sizes ---
+
+export const Small: Story = {
+  args: { label: 'Small Input', size: 'sm' },
+};
+
+export const Medium: Story = {
+  args: { label: 'Medium Input', size: 'md' },
+};
+
+export const Large: Story = {
+  args: { label: 'Large Input', size: 'lg' },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex w-80 flex-col gap-6">
+      <Input label="Small" size="sm" placeholder="Small input..." />
+      <Input label="Medium" size="md" placeholder="Medium input..." />
+      <Input label="Large" size="lg" placeholder="Large input..." />
+    </div>
+  ),
+};
+
+// --- States ---
+
+export const Disabled: Story = {
+  args: {
+    label: 'Disabled',
+    placeholder: 'Cannot edit...',
+    disabled: true,
+  },
+};
+
+export const Required: Story = {
+  args: {
+    label: 'Required Field',
+    placeholder: 'This field is required...',
+    required: true,
+  },
+};
+
+// --- Types ---
+
+export const Password: Story = {
+  args: {
+    label: 'Password',
+    type: 'password',
+    placeholder: 'Enter password...',
+  },
+};
+
+export const Number: Story = {
+  args: {
+    label: 'Amount',
+    type: 'number',
+    placeholder: '0.00',
+  },
+};


### PR DESCRIPTION
## Summary
- Expand Button stories: all 4 variants, 3 sizes, icons, loading, disabled
- Add Input stories: default, helper text, error, all sizes, disabled, required, password/number types
- Establish story pattern with argTypes controls and render composition

## Test plan
- [x] `pnpm run ci` passes
- [x] Stories render correctly in Storybook with Chromatic Refraction theme

closes #56