### PR TITLE
feat(storybook): add stories for all remaining components

### DIFF
--- a/src/shared/components/Badge/Badge.stories.tsx
+++ b/src/shared/components/Badge/Badge.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Badge } from './Badge';
+
+const meta = {
+  title: 'Components/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'primary', 'success', 'warning', 'danger', 'muted'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md'],
+    },
+    children: { control: 'text' },
+  },
+  args: {
+    children: 'Badge',
+    variant: 'default',
+    size: 'md',
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-3">
+      <Badge variant="default">Default</Badge>
+      <Badge variant="primary">Primary</Badge>
+      <Badge variant="success">Success</Badge>
+      <Badge variant="warning">Warning</Badge>
+      <Badge variant="danger">Danger</Badge>
+      <Badge variant="muted">Muted</Badge>
+    </div>
+  ),
+};
+
+export const Small: Story = {
+  args: { size: 'sm', children: 'Small' },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <Badge size="sm">Small</Badge>
+      <Badge size="md">Medium</Badge>
+    </div>
+  ),
+};
+
+export const LongText: Story = {
+  render: () => (
+    <div className="w-40">
+      <Badge>This is a very long badge text that truncates</Badge>
+    </div>
+  ),
+};
+
+export const StatusExamples: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-3">
+      <Badge variant="success">Active</Badge>
+      <Badge variant="warning">Pending</Badge>
+      <Badge variant="danger">Overdue</Badge>
+      <Badge variant="primary">+12.5%</Badge>
+      <Badge variant="muted">Cleared</Badge>
+    </div>
+  ),
+};

--- a/src/shared/components/Card/Card.stories.tsx
+++ b/src/shared/components/Card/Card.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Button } from '@/shared/components/Button';
+import { Text } from '@/shared/components/Text';
+
+import { Card } from './Card';
+
+const meta = {
+  title: 'Components/Card',
+  component: Card,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'outlined'],
+    },
+  },
+  args: {
+    variant: 'default',
+  },
+} satisfies Meta<typeof Card>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Card {...args}>
+      <Card.Body>
+        <Text variant="body">Default glass card with content.</Text>
+      </Card.Body>
+    </Card>
+  ),
+};
+
+export const Outlined: Story = {
+  render: () => (
+    <Card variant="outlined">
+      <Card.Body>
+        <Text variant="body">Outlined card with surface-high background.</Text>
+      </Card.Body>
+    </Card>
+  ),
+};
+
+export const WithHeaderAndFooter: Story = {
+  render: () => (
+    <Card>
+      <Card.Header>
+        <Text variant="h3">Card Title</Text>
+        <Text variant="bodySmall" className="mt-1">
+          A description of this card&apos;s content.
+        </Text>
+      </Card.Header>
+      <Card.Body>
+        <Text variant="body">
+          This is the main body content of the card. It can contain any
+          components.
+        </Text>
+      </Card.Body>
+      <Card.Footer>
+        <Button variant="ghost" size="sm">
+          Cancel
+        </Button>
+        <Button variant="primary" size="sm">
+          Save
+        </Button>
+      </Card.Footer>
+    </Card>
+  ),
+};
+
+export const BodyOnly: Story = {
+  render: () => (
+    <Card>
+      <Card.Body>
+        <Text variant="body">
+          A card with only body content — no header or footer.
+        </Text>
+      </Card.Body>
+    </Card>
+  ),
+};
+
+export const BothVariants: Story = {
+  render: () => (
+    <div className="flex gap-6">
+      <Card className="w-64">
+        <Card.Body>
+          <Text variant="label">Default (Glass)</Text>
+          <Text variant="bodySmall" className="mt-2">
+            Frosted glass with backdrop blur.
+          </Text>
+        </Card.Body>
+      </Card>
+      <Card variant="outlined" className="w-64">
+        <Card.Body>
+          <Text variant="label">Outlined</Text>
+          <Text variant="bodySmall" className="mt-2">
+            Solid surface-high background.
+          </Text>
+        </Card.Body>
+      </Card>
+    </div>
+  ),
+};

--- a/src/shared/components/ErrorBoundary/ErrorBoundary.stories.tsx
+++ b/src/shared/components/ErrorBoundary/ErrorBoundary.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Button } from '@/shared/components/Button';
+import { Text } from '@/shared/components/Text';
+
+import { ErrorBoundary } from './ErrorBoundary';
+
+function ThrowOnClick(): React.ReactElement {
+  const [shouldThrow, setShouldThrow] = useState(false);
+  if (shouldThrow) {
+    throw new Error('Intentional demo error');
+  }
+  return (
+    <div className="space-y-4">
+      <Text variant="body">
+        This component is healthy. Click below to simulate a crash.
+      </Text>
+      <Button
+        variant="danger"
+        size="sm"
+        onClick={() => {
+          setShouldThrow(true);
+        }}
+      >
+        Trigger Error
+      </Button>
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Layout/ErrorBoundary',
+  component: ErrorBoundary,
+  tags: ['autodocs'],
+  args: {
+    children: null,
+  },
+} satisfies Meta<typeof ErrorBoundary>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Normal: Story = {
+  args: {
+    children: (
+      <Text variant="body">
+        No error — children render normally. The error boundary is invisible
+        until something breaks.
+      </Text>
+    ),
+  },
+};
+
+export const ErrorFallback: Story = {
+  args: {
+    children: <ThrowOnClick />,
+  },
+};

--- a/src/shared/components/Icon/Icon.stories.tsx
+++ b/src/shared/components/Icon/Icon.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Text } from '@/shared/components/Text';
+
+import { Icon } from './Icon';
+import { iconPaths } from './icons';
+
+const allIconNames = Object.keys(iconPaths) as (keyof typeof iconPaths)[];
+
+const meta = {
+  title: 'Components/Icon',
+  component: Icon,
+  tags: ['autodocs'],
+  argTypes: {
+    name: {
+      control: 'select',
+      options: allIconNames,
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+    'aria-label': { control: 'text' },
+  },
+  args: {
+    name: 'dashboard',
+    size: 'md',
+  },
+} satisfies Meta<typeof Icon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-6">
+      <Icon name="settings" size="sm" />
+      <Icon name="settings" size="md" />
+      <Icon name="settings" size="lg" />
+    </div>
+  ),
+};
+
+export const Meaningful: Story = {
+  args: {
+    name: 'alert',
+    'aria-label': 'Warning: action required',
+    size: 'lg',
+  },
+};
+
+export const IconGrid: Story = {
+  render: () => (
+    <div className="grid grid-cols-4 gap-6 sm:grid-cols-6 md:grid-cols-8">
+      {allIconNames.map((name) => (
+        <div
+          key={name}
+          className="flex flex-col items-center gap-2 rounded-card-nested p-3 text-center hover:bg-glass"
+        >
+          <Icon name={name} size="lg" className="text-foreground" />
+          <Text variant="caption" className="text-[10px]">
+            {name}
+          </Text>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/src/shared/components/Modal/Modal.stories.tsx
+++ b/src/shared/components/Modal/Modal.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Button } from '@/shared/components/Button';
+import { Input } from '@/shared/components/Input';
+import { Text } from '@/shared/components/Text';
+
+import { Modal } from './Modal';
+
+/*
+ * Modal is a controlled component (isOpen/onClose), so we can't use
+ * Storybook's args directly. Instead, we use a ModalDemo wrapper
+ * with its own useState and type the meta around that wrapper.
+ */
+
+function ModalDemo({
+  size = 'md',
+  title,
+  description,
+  children,
+}: {
+  size?: 'sm' | 'md' | 'lg';
+  title: string;
+  description?: string;
+  children?: React.ReactNode;
+}): React.ReactElement {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <Button
+        onClick={() => {
+          setIsOpen(true);
+        }}
+      >
+        Open Modal
+      </Button>
+      <Modal
+        isOpen={isOpen}
+        onClose={() => {
+          setIsOpen(false);
+        }}
+        title={title}
+        {...(description !== undefined ? { description } : {})}
+        size={size}
+      >
+        {children ?? <Text variant="body">Modal body content goes here.</Text>}
+      </Modal>
+    </>
+  );
+}
+
+const meta = {
+  title: 'Components/Modal',
+  component: ModalDemo,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+    title: { control: 'text' },
+    description: { control: 'text' },
+  },
+  args: {
+    title: 'Modal Title',
+    description: 'A description of what this modal does.',
+    size: 'md',
+  },
+} satisfies Meta<typeof ModalDemo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Small: Story = {
+  args: { title: 'Small Modal', size: 'sm' },
+};
+
+export const Large: Story = {
+  args: {
+    title: 'Large Modal',
+    description: 'This is a wider dialog.',
+    size: 'lg',
+  },
+};
+
+export const WithForm: Story = {
+  args: { title: 'Add Transaction', description: 'Enter the transaction details.' },
+  render: (args) => (
+    <ModalDemo title={args.title}>
+      <div className="space-y-4">
+        <Input label="Description" placeholder="e.g., Grocery Store" />
+        <Input label="Amount" type="number" placeholder="0.00" />
+        <div className="flex justify-end gap-3 pt-4">
+          <Button variant="ghost" size="sm">
+            Cancel
+          </Button>
+          <Button variant="primary" size="sm">
+            Save
+          </Button>
+        </div>
+      </div>
+    </ModalDemo>
+  ),
+};

--- a/src/shared/components/PageContent/PageContent.stories.tsx
+++ b/src/shared/components/PageContent/PageContent.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Card } from '@/shared/components/Card';
+import { Text } from '@/shared/components/Text';
+
+import { PageContent } from './PageContent';
+
+const meta = {
+  title: 'Layout/PageContent',
+  component: PageContent,
+  tags: ['autodocs'],
+} satisfies Meta<typeof PageContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <PageContent>
+      <Text variant="body">
+        Page content renders here with consistent top margin spacing.
+      </Text>
+    </PageContent>
+  ),
+};
+
+export const WithCards: Story = {
+  render: () => (
+    <PageContent>
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        <Card>
+          <Card.Body>
+            <Text variant="h4">Card One</Text>
+            <Text variant="bodySmall" className="mt-2">
+              Content inside a page content area.
+            </Text>
+          </Card.Body>
+        </Card>
+        <Card>
+          <Card.Body>
+            <Text variant="h4">Card Two</Text>
+            <Text variant="bodySmall" className="mt-2">
+              Another card in the grid.
+            </Text>
+          </Card.Body>
+        </Card>
+      </div>
+    </PageContent>
+  ),
+};
+
+export const Empty: Story = {
+  render: () => <PageContent />,
+};

--- a/src/shared/components/PageHeader/PageHeader.stories.tsx
+++ b/src/shared/components/PageHeader/PageHeader.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Button } from '@/shared/components/Button';
+import { Icon } from '@/shared/components/Icon';
+
+import { PageHeader } from './PageHeader';
+
+const meta = {
+  title: 'Layout/PageHeader',
+  component: PageHeader,
+  tags: ['autodocs'],
+  argTypes: {
+    title: { control: 'text' },
+    subtitle: { control: 'text' },
+  },
+  args: {
+    title: 'Dashboard',
+  },
+} satisfies Meta<typeof PageHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithSubtitle: Story = {
+  args: {
+    title: 'Dashboard',
+    subtitle: 'Your financial overview at a glance.',
+  },
+};
+
+export const WithActions: Story = {
+  render: () => (
+    <PageHeader
+      title="Transactions"
+      subtitle="View and manage your transactions."
+    >
+      <Button
+        variant="secondary"
+        size="sm"
+        leftIcon={<Icon name="search" size="sm" />}
+      >
+        Search
+      </Button>
+      <Button
+        variant="primary"
+        size="sm"
+        leftIcon={<Icon name="plus" size="sm" />}
+      >
+        Add Transaction
+      </Button>
+    </PageHeader>
+  ),
+};
+
+export const LongTitle: Story = {
+  args: {
+    title: 'This Is a Very Long Page Title That Demonstrates Wrapping Behavior',
+    subtitle: 'Subtitles also wrap gracefully on smaller viewports.',
+  },
+};

--- a/src/shared/components/SidebarNav/SidebarNav.stories.tsx
+++ b/src/shared/components/SidebarNav/SidebarNav.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MemoryRouter } from 'react-router';
+
+import { SidebarNav } from './SidebarNav';
+
+/*
+ * SidebarNav requires a Router context because it uses NavLink.
+ * We wrap it in MemoryRouter for Storybook — same pattern as tests.
+ */
+const meta = {
+  title: 'Layout/SidebarNav',
+  component: SidebarNav,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <div className="w-64 rounded-card border border-border bg-glass p-4 glass-edge">
+          <Story />
+        </div>
+      </MemoryRouter>
+    ),
+  ],
+} satisfies Meta<typeof SidebarNav>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const HouseholdsActive: Story = {
+  decorators: [
+    (Story) => (
+      <MemoryRouter initialEntries={['/households']}>
+        <div className="w-64 rounded-card border border-border bg-glass p-4 glass-edge">
+          <Story />
+        </div>
+      </MemoryRouter>
+    ),
+  ],
+};
+
+export const SettingsActive: Story = {
+  decorators: [
+    (Story) => (
+      <MemoryRouter initialEntries={['/settings']}>
+        <div className="w-64 rounded-card border border-border bg-glass p-4 glass-edge">
+          <Story />
+        </div>
+      </MemoryRouter>
+    ),
+  ],
+};

--- a/src/shared/components/Spinner/Spinner.stories.tsx
+++ b/src/shared/components/Spinner/Spinner.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Button } from '@/shared/components/Button';
+
+import { Spinner } from './Spinner';
+
+const meta = {
+  title: 'Components/Spinner',
+  component: Spinner,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+    'aria-label': { control: 'text' },
+  },
+  args: {
+    size: 'md',
+  },
+} satisfies Meta<typeof Spinner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-6">
+      <Spinner size="sm" />
+      <Spinner size="md" />
+      <Spinner size="lg" />
+    </div>
+  ),
+};
+
+export const ColorInheritance: Story = {
+  render: () => (
+    <div className="flex items-center gap-6">
+      <div className="text-primary">
+        <Spinner size="md" />
+      </div>
+      <div className="text-tertiary">
+        <Spinner size="md" />
+      </div>
+      <div className="text-danger">
+        <Spinner size="md" />
+      </div>
+      <div className="text-foreground-muted">
+        <Spinner size="md" />
+      </div>
+    </div>
+  ),
+};
+
+export const InsideButton: Story = {
+  render: () => (
+    <Button isLoading variant="primary">
+      Saving...
+    </Button>
+  ),
+};

--- a/src/shared/components/Text/Text.stories.tsx
+++ b/src/shared/components/Text/Text.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Text } from './Text';
+
+const meta = {
+  title: 'Components/Text',
+  component: Text,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: [
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'body',
+        'bodySmall',
+        'caption',
+        'label',
+      ],
+    },
+    as: {
+      control: 'select',
+      options: ['h1', 'h2', 'h3', 'h4', 'p', 'span', 'div'],
+    },
+    isTruncated: { control: 'boolean' },
+    children: { control: 'text' },
+  },
+  args: {
+    variant: 'body',
+    children: 'The quick brown fox jumps over the lazy dog.',
+  },
+} satisfies Meta<typeof Text>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const TypeScale: Story = {
+  render: () => (
+    <div className="space-y-6">
+      <Text variant="h1">Heading 1 — Display</Text>
+      <Text variant="h2">Heading 2 — Headline</Text>
+      <Text variant="h3">Heading 3 — Title</Text>
+      <Text variant="h4">Heading 4 — Subtitle</Text>
+      <Text variant="body">
+        Body — The quick brown fox jumps over the lazy dog. This is how
+        paragraph text renders in the Chromatic Refraction design system.
+      </Text>
+      <Text variant="bodySmall">
+        Body Small — Secondary text for descriptions, helper copy, and
+        supplementary information.
+      </Text>
+      <Text variant="caption">
+        Caption — Used for metadata, timestamps, and micro-copy.
+      </Text>
+      <Text variant="label">
+        Label — Uppercase tracking for navigation and tags
+      </Text>
+    </div>
+  ),
+};
+
+export const PolymorphicAs: Story = {
+  render: () => (
+    <div className="space-y-4">
+      <Text variant="h1" as="span">
+        h1 visuals on a span
+      </Text>
+      <Text variant="body" as="div">
+        body visuals on a div
+      </Text>
+      <Text variant="label" as="p">
+        label visuals on a paragraph
+      </Text>
+    </div>
+  ),
+};
+
+export const Truncated: Story = {
+  render: () => (
+    <div className="w-64">
+      <Text variant="body" isTruncated>
+        This is a very long text that will be truncated with an ellipsis when it
+        overflows.
+      </Text>
+    </div>
+  ),
+};
+
+export const Heading1: Story = {
+  args: { variant: 'h1', children: 'Heading 1' },
+};
+export const Heading2: Story = {
+  args: { variant: 'h2', children: 'Heading 2' },
+};
+export const Heading3: Story = {
+  args: { variant: 'h3', children: 'Heading 3' },
+};
+export const Heading4: Story = {
+  args: { variant: 'h4', children: 'Heading 4' },
+};
+export const Body: Story = { args: { variant: 'body' } };
+export const BodySmall: Story = {
+  args: { variant: 'bodySmall', children: 'Small body text' },
+};
+export const Caption: Story = {
+  args: { variant: 'caption', children: 'Caption text' },
+};
+export const Label: Story = {
+  args: { variant: 'label', children: 'Label text' },
+};


### PR DESCRIPTION
## Summary
- Add Storybook stories for all 10 remaining components (Badge, Card, Spinner, Modal, Icon, Text, PageHeader, PageContent, ErrorBoundary, SidebarNav)
- Every component now has interactive controls and composition examples
- Modal uses wrapper component for controlled state, SidebarNav uses MemoryRouter decorator

## Test plan
- [x] `pnpm run ci` passes
- [x] All stories render in Storybook with Chromatic Refraction theme

closes #57, closes #58, closes #59, closes #60