### PR TITLE
fix(storybook): fix nested Router error in SidebarNav stories

### DIFF
--- a/src/shared/components/SidebarNav/SidebarNav.stories.tsx
+++ b/src/shared/components/SidebarNav/SidebarNav.stories.tsx
@@ -1,26 +1,43 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { SidebarNav } from './SidebarNav';
 
 /*
  * SidebarNav requires a Router context because it uses NavLink.
- * We wrap it in MemoryRouter for Storybook — same pattern as tests.
+ * Each story provides its own MemoryRouter with the appropriate
+ * initialEntries to show the correct active state.
  */
+
+function SidebarNavWrapper({
+  initialRoute = '/dashboard',
+}: {
+  initialRoute?: string;
+}): ReactElement {
+  return (
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <div className="w-64 rounded-card border border-border bg-glass p-4 glass-edge">
+        <SidebarNav />
+      </div>
+    </MemoryRouter>
+  );
+}
+
 const meta = {
   title: 'Layout/SidebarNav',
-  component: SidebarNav,
+  component: SidebarNavWrapper,
   tags: ['autodocs'],
-  decorators: [
-    (Story) => (
-      <MemoryRouter initialEntries={['/dashboard']}>
-        <div className="w-64 rounded-card border border-border bg-glass p-4 glass-edge">
-          <Story />
-        </div>
-      </MemoryRouter>
-    ),
-  ],
-} satisfies Meta<typeof SidebarNav>;
+  args: {
+    initialRoute: '/dashboard',
+  },
+  argTypes: {
+    initialRoute: {
+      control: 'select',
+      options: ['/dashboard', '/households', '/settings'],
+    },
+  },
+} satisfies Meta<typeof SidebarNavWrapper>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -28,25 +45,9 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 export const HouseholdsActive: Story = {
-  decorators: [
-    (Story) => (
-      <MemoryRouter initialEntries={['/households']}>
-        <div className="w-64 rounded-card border border-border bg-glass p-4 glass-edge">
-          <Story />
-        </div>
-      </MemoryRouter>
-    ),
-  ],
+  args: { initialRoute: '/households' },
 };
 
 export const SettingsActive: Story = {
-  decorators: [
-    (Story) => (
-      <MemoryRouter initialEntries={['/settings']}>
-        <div className="w-64 rounded-card border border-border bg-glass p-4 glass-edge">
-          <Story />
-        </div>
-      </MemoryRouter>
-    ),
-  ],
+  args: { initialRoute: '/settings' },
 };


### PR DESCRIPTION
## Summary
- Fix "cannot render Router inside another Router" error on HouseholdsActive and SettingsActive stories
- Replace nested MemoryRouter decorators with a wrapper component that takes initialRoute as prop