### PR TITLE
feat(auth): add auth context, provider, and useAuth hook

### DIFF
--- a/src/features/auth/AuthContext.ts
+++ b/src/features/auth/AuthContext.ts
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+
+import { type AuthContextValue } from './types';
+
+// Starts as null — useAuth enforces that consumers are inside a provider.
+export const AuthContext = createContext<AuthContextValue | null>(null);

--- a/src/features/auth/AuthProvider.test.tsx
+++ b/src/features/auth/AuthProvider.test.tsx
@@ -1,0 +1,176 @@
+import { act, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AuthProvider } from './AuthProvider';
+import { clearToken, getToken, saveToken } from './tokenService';
+import { useAuth } from './useAuth';
+
+// Isolate the token service — these tests verify context behaviour, not storage.
+// vi.mock is hoisted by Vitest above all imports, so the mock is in place before
+// the module under test runs. The static imports above reflect the mocked module.
+vi.mock('./tokenService', () => ({
+  getToken: vi.fn(),
+  saveToken: vi.fn(),
+  clearToken: vi.fn(),
+}));
+
+const mockGetToken = vi.mocked(getToken);
+const mockSaveToken = vi.mocked(saveToken);
+const mockClearToken = vi.mocked(clearToken);
+
+// Helper: a consumer component that exposes auth state via accessible text.
+function AuthConsumer(): React.ReactElement {
+  const { state, login, logout } = useAuth();
+  return (
+    <div>
+      <span data-testid="status">
+        {state.isAuthenticated ? 'authenticated' : 'unauthenticated'}
+      </span>
+      {state.isAuthenticated && <span data-testid="token">{state.token}</span>}
+      <button
+        onClick={() => {
+          login('tok-123', '2099-01-01T00:00:00Z');
+        }}
+      >
+        Login
+      </button>
+      <button onClick={logout}>Logout</button>
+    </div>
+  );
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('initial load', () => {
+    it('treats the user as authenticated when a valid token exists in storage', () => {
+      mockGetToken.mockReturnValue({
+        token: 'stored-token',
+        expiresAt: '2099-01-01T00:00:00Z',
+      });
+
+      render(
+        <AuthProvider>
+          <AuthConsumer />
+        </AuthProvider>,
+      );
+
+      expect(screen.getByTestId('status')).toHaveTextContent('authenticated');
+      expect(screen.getByTestId('token')).toHaveTextContent('stored-token');
+    });
+
+    it('treats the user as unauthenticated when no token is stored', () => {
+      mockGetToken.mockReturnValue(null);
+
+      render(
+        <AuthProvider>
+          <AuthConsumer />
+        </AuthProvider>,
+      );
+
+      expect(screen.getByTestId('status')).toHaveTextContent('unauthenticated');
+      expect(screen.queryByTestId('token')).toBeNull();
+    });
+
+    it('treats the user as unauthenticated when the stored token is expired', () => {
+      // getToken already returns null for expired tokens (enforced by tokenService).
+      // The context trusts the service — null means unauthenticated.
+      mockGetToken.mockReturnValue(null);
+
+      render(
+        <AuthProvider>
+          <AuthConsumer />
+        </AuthProvider>,
+      );
+
+      expect(screen.getByTestId('status')).toHaveTextContent('unauthenticated');
+    });
+  });
+
+  describe('login()', () => {
+    it('updates state to authenticated and persists the token', () => {
+      mockGetToken.mockReturnValue(null);
+
+      render(
+        <AuthProvider>
+          <AuthConsumer />
+        </AuthProvider>,
+      );
+
+      act(() => {
+        screen.getByRole('button', { name: 'Login' }).click();
+      });
+
+      expect(screen.getByTestId('status')).toHaveTextContent('authenticated');
+      expect(screen.getByTestId('token')).toHaveTextContent('tok-123');
+      expect(mockSaveToken).toHaveBeenCalledWith({
+        token: 'tok-123',
+        expiresAt: '2099-01-01T00:00:00Z',
+      });
+    });
+  });
+
+  describe('logout()', () => {
+    it('updates state to unauthenticated and clears the token', () => {
+      mockGetToken.mockReturnValue({
+        token: 'stored-token',
+        expiresAt: '2099-01-01T00:00:00Z',
+      });
+
+      render(
+        <AuthProvider>
+          <AuthConsumer />
+        </AuthProvider>,
+      );
+
+      act(() => {
+        screen.getByRole('button', { name: 'Logout' }).click();
+      });
+
+      expect(screen.getByTestId('status')).toHaveTextContent('unauthenticated');
+      expect(screen.queryByTestId('token')).toBeNull();
+      expect(mockClearToken).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('multiple consumers', () => {
+    it('all consumers reflect the same state after login', () => {
+      mockGetToken.mockReturnValue(null);
+
+      render(
+        <AuthProvider>
+          <AuthConsumer />
+          <AuthConsumer />
+        </AuthProvider>,
+      );
+
+      act(() => {
+        // Click the first Login button — both consumers share the same context.
+        screen.getAllByRole('button', { name: 'Login' })[0]?.click();
+      });
+
+      const statuses = screen.getAllByTestId('status');
+      expect(statuses).toHaveLength(2);
+      statuses.forEach((el) => {
+        expect(el).toHaveTextContent('authenticated');
+      });
+    });
+  });
+
+  describe('useAuth()', () => {
+    it('throws a descriptive error when used outside AuthProvider', () => {
+      // Suppress React's error boundary console noise during this test.
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+
+      expect(() => render(<AuthConsumer />)).toThrow(
+        /useAuth must be used within an AuthProvider/,
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/src/features/auth/AuthProvider.tsx
+++ b/src/features/auth/AuthProvider.tsx
@@ -1,0 +1,56 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { AuthContext } from './AuthContext';
+import { clearToken, getToken, saveToken } from './tokenService';
+import { type AuthContextValue, type AuthState } from './types';
+
+interface AuthProviderProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Wrap the application root with AuthProvider to make auth state available
+ * to every component via useAuth().
+ *
+ * On mount it reads from the token service: if a valid (non-expired) token
+ * is in storage, the user starts as authenticated without re-logging in.
+ *
+ * React rendering note: useState with an initialiser function runs once on
+ * mount, so getToken() is only called during the first render — not on every
+ * re-render. This is the idiomatic way to derive initial state from an
+ * external source without a useEffect.
+ */
+export function AuthProvider({
+  children,
+}: AuthProviderProps): React.ReactElement {
+  const [state, setState] = useState<AuthState>(() => {
+    const stored = getToken();
+    if (stored === null) return { isAuthenticated: false };
+    return {
+      isAuthenticated: true,
+      token: stored.token,
+      expiresAt: stored.expiresAt,
+    };
+  });
+
+  // useCallback keeps the reference stable so consumers that memoize won't
+  // re-render unnecessarily when the provider itself re-renders.
+  const login = useCallback((token: string, expiresAt: string): void => {
+    saveToken({ token, expiresAt });
+    setState({ isAuthenticated: true, token, expiresAt });
+  }, []);
+
+  const logout = useCallback((): void => {
+    clearToken();
+    setState({ isAuthenticated: false });
+  }, []);
+
+  // useMemo ensures the context value reference is stable when state hasn't
+  // changed — prevents re-renders of all consumers on unrelated provider renders.
+  const value = useMemo<AuthContextValue>(
+    () => ({ state, login, logout }),
+    [state, login, logout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,2 +1,4 @@
+export { AuthProvider } from './AuthProvider';
 export { clearToken, getToken, saveToken } from './tokenService';
-export type { AuthToken } from './types';
+export type { AuthContextValue, AuthState, AuthToken } from './types';
+export { useAuth } from './useAuth';

--- a/src/features/auth/types.ts
+++ b/src/features/auth/types.ts
@@ -2,3 +2,14 @@ export interface AuthToken {
   token: string;
   expiresAt: string; // ISO 8601 / RFC 3339 UTC — e.g. "2026-04-07T12:00:00Z"
 }
+
+// Discriminated union: components narrow on isAuthenticated to access token fields.
+export type AuthState =
+  | { isAuthenticated: false }
+  | { isAuthenticated: true; token: string; expiresAt: string };
+
+export interface AuthContextValue {
+  state: AuthState;
+  login: (token: string, expiresAt: string) => void;
+  logout: () => void;
+}

--- a/src/features/auth/useAuth.ts
+++ b/src/features/auth/useAuth.ts
@@ -1,0 +1,16 @@
+import { useContext } from 'react';
+
+import { AuthContext } from './AuthContext';
+import { type AuthContextValue } from './types';
+
+/**
+ * Returns the current auth state and login/logout actions.
+ * Must be called inside a component that is a descendant of AuthProvider.
+ */
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (context === null) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router';
 
 import App from './App.tsx';
+import { AuthProvider } from './features/auth/AuthProvider';
 import './index.css';
 
 const rootElement = document.getElementById('root');
@@ -13,7 +14,9 @@ if (!rootElement) {
 createRoot(rootElement).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </StrictMode>,
 );


### PR DESCRIPTION
## Summary
- Introduces `AuthProvider` at the app root as the single source of truth for auth state
- Restores session on mount via the token service — no re-login if a valid token exists
- Exposes `login(token, expiresAt)` and `logout()` actions backed by the token service
- `useAuth()` hook gives any component access to auth state and actions
- `AuthState` discriminated union enables exhaustive narrowing in consumers

Closes #67 | Part of M1: Auth Foundation

## Test plan
- [x] `pnpm ci` passes (lint + type-check + test:coverage + build)
- [x] `/project:verify-issue` verdict: PASS
- [x] `/project:review` verdict: PASS
- [x] Accessibility: N/A — no UI introduced in this story