### PR TITLE
feat(auth): add ProtectedRoute and PublicRoute guards

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,19 +1,36 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import App from './App';
+import { AuthProvider } from './features/auth/AuthProvider';
+
+// The App routes are now guarded by ProtectedRoute which reads from AuthProvider.
+// Mock the token service so AuthProvider initialises with an authenticated user —
+// App.test.tsx tests routing structure, not auth behaviour.
+vi.mock('./features/auth/tokenService', () => ({
+  getToken: vi
+    .fn()
+    .mockReturnValue({ token: 'test-tok', expiresAt: '2099-01-01T00:00:00Z' }),
+  saveToken: vi.fn(),
+  clearToken: vi.fn(),
+}));
 
 /*
  * MemoryRouter: In tests we can't use BrowserRouter (no real browser URL bar).
  * MemoryRouter lets us set initialEntries to simulate navigating to a URL.
  * Think of it like a mock HTTP request in Go — you control the input URL
  * without needing a real server.
+ *
+ * AuthProvider must wrap App (mirroring main.tsx) so ProtectedRoute can read
+ * auth state. The mocked token service above sets the authenticated state.
  */
 function renderWithRouter(initialEntries: string[] = ['/']) {
   return render(
     <MemoryRouter initialEntries={initialEntries}>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </MemoryRouter>,
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import { Navigate, Route, Routes } from 'react-router';
 
+import { ProtectedRoute } from '@/features/auth/components/ProtectedRoute';
+import { PublicRoute } from '@/features/auth/components/PublicRoute';
 import { DashboardPage } from '@/pages/DashboardPage';
 import { HouseholdsPage } from '@/pages/HouseholdsPage';
 import { NotFoundPage } from '@/pages/NotFoundPage';
@@ -10,41 +12,52 @@ import { ErrorBoundary } from '@/shared/components/ErrorBoundary';
 /*
  * App — route configuration with layout wrapper and error boundaries.
  *
- * Each feature route is wrapped in its own ErrorBoundary so a crash
- * in one feature (e.g., Households) doesn't take down the sidebar
- * or other features. The layout shell remains functional.
+ * ProtectedRoute guards all internal pages — unauthenticated users are
+ * redirected to /login before reaching any child route.
+ *
+ * PublicRoute guards /login — authenticated users are redirected to /dashboard
+ * so they cannot reach the login page while already signed in.
  */
 function App(): React.ReactElement {
   return (
     <Routes>
-      <Route element={<AppLayout />}>
-        <Route path="/" element={<Navigate to="/dashboard" replace />} />
-        <Route
-          path="/dashboard"
-          element={
-            <ErrorBoundary>
-              <DashboardPage />
-            </ErrorBoundary>
-          }
-        />
-        <Route
-          path="/households"
-          element={
-            <ErrorBoundary>
-              <HouseholdsPage />
-            </ErrorBoundary>
-          }
-        />
-        <Route
-          path="/settings"
-          element={
-            <ErrorBoundary>
-              <SettingsPage />
-            </ErrorBoundary>
-          }
-        />
-        <Route path="*" element={<NotFoundPage />} />
+      {/* Public routes — accessible only when unauthenticated */}
+      <Route element={<PublicRoute />}>
+        <Route path="/login" element={<p>Login coming soon</p>} />
       </Route>
+
+      {/* Protected routes — require authentication */}
+      <Route element={<ProtectedRoute />}>
+        <Route element={<AppLayout />}>
+          <Route path="/" element={<Navigate to="/dashboard" replace />} />
+          <Route
+            path="/dashboard"
+            element={
+              <ErrorBoundary>
+                <DashboardPage />
+              </ErrorBoundary>
+            }
+          />
+          <Route
+            path="/households"
+            element={
+              <ErrorBoundary>
+                <HouseholdsPage />
+              </ErrorBoundary>
+            }
+          />
+          <Route
+            path="/settings"
+            element={
+              <ErrorBoundary>
+                <SettingsPage />
+              </ErrorBoundary>
+            }
+          />
+        </Route>
+      </Route>
+
+      <Route path="*" element={<NotFoundPage />} />
     </Routes>
   );
 }

--- a/src/features/auth/components/ProtectedRoute.test.tsx
+++ b/src/features/auth/components/ProtectedRoute.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useAuth } from '../useAuth';
+import { ProtectedRoute } from './ProtectedRoute';
+
+// Mock useAuth so tests control auth state without a real provider or localStorage.
+// vi.mock is hoisted by Vitest above all imports at runtime, so the mock is in
+// place before any module under test executes — import order in source is irrelevant
+// to when the mock takes effect.
+vi.mock('../useAuth', () => ({ useAuth: vi.fn() }));
+
+const mockUseAuth = vi.mocked(useAuth);
+
+function ProtectedPage(): React.ReactElement {
+  return <p>Protected content</p>;
+}
+function LoginPage(): React.ReactElement {
+  return <p>Login page</p>;
+}
+
+function renderWithRoutes(initialPath: string): void {
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route element={<ProtectedRoute />}>
+          <Route path="/dashboard" element={<ProtectedPage />} />
+        </Route>
+        <Route path="/login" element={<LoginPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ProtectedRoute', () => {
+  it('renders the child outlet when the user is authenticated', () => {
+    mockUseAuth.mockReturnValue({
+      state: {
+        isAuthenticated: true,
+        token: 'tok',
+        expiresAt: '2099-01-01T00:00:00Z',
+      },
+      login: vi.fn(),
+      logout: vi.fn(),
+    });
+
+    renderWithRoutes('/dashboard');
+
+    expect(screen.getByText('Protected content')).toBeInTheDocument();
+    expect(screen.queryByText('Login page')).toBeNull();
+  });
+
+  it('redirects to /login when the user is unauthenticated', () => {
+    mockUseAuth.mockReturnValue({
+      state: { isAuthenticated: false },
+      login: vi.fn(),
+      logout: vi.fn(),
+    });
+
+    renderWithRoutes('/dashboard');
+
+    expect(screen.getByText('Login page')).toBeInTheDocument();
+    expect(screen.queryByText('Protected content')).toBeNull();
+  });
+
+  it('redirects to /login when navigating directly to a deep protected URL', () => {
+    mockUseAuth.mockReturnValue({
+      state: { isAuthenticated: false },
+      login: vi.fn(),
+      logout: vi.fn(),
+    });
+
+    renderWithRoutes('/dashboard');
+
+    expect(screen.getByText('Login page')).toBeInTheDocument();
+  });
+});

--- a/src/features/auth/components/ProtectedRoute.tsx
+++ b/src/features/auth/components/ProtectedRoute.tsx
@@ -1,0 +1,24 @@
+import { Navigate, Outlet } from 'react-router';
+
+import { useAuth } from '../useAuth';
+
+/**
+ * Wraps routes that require authentication.
+ *
+ * React Router note: this component uses <Outlet /> as the rendering slot for
+ * child routes, rather than accepting a `children` prop. This is the idiomatic
+ * pattern for layout/guard routes in React Router v6+ — the guard sits between
+ * the parent <Route> and its children in the route tree.
+ *
+ * If unauthenticated, <Navigate replace /> replaces the current history entry
+ * so the browser back button doesn't loop the user back to the protected route.
+ */
+export function ProtectedRoute(): React.ReactElement {
+  const { state } = useAuth();
+
+  if (!state.isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/src/features/auth/components/PublicRoute.test.tsx
+++ b/src/features/auth/components/PublicRoute.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useAuth } from '../useAuth';
+import { PublicRoute } from './PublicRoute';
+
+// vi.mock is hoisted above all imports at runtime by Vitest.
+vi.mock('../useAuth', () => ({ useAuth: vi.fn() }));
+
+const mockUseAuth = vi.mocked(useAuth);
+
+function LoginPage(): React.ReactElement {
+  return <p>Login page</p>;
+}
+function DashboardPage(): React.ReactElement {
+  return <p>Dashboard page</p>;
+}
+
+function renderWithRoutes(initialPath: string): void {
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route element={<PublicRoute />}>
+          <Route path="/login" element={<LoginPage />} />
+        </Route>
+        <Route path="/dashboard" element={<DashboardPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('PublicRoute', () => {
+  it('renders the child outlet when the user is unauthenticated', () => {
+    mockUseAuth.mockReturnValue({
+      state: { isAuthenticated: false },
+      login: vi.fn(),
+      logout: vi.fn(),
+    });
+
+    renderWithRoutes('/login');
+
+    expect(screen.getByText('Login page')).toBeInTheDocument();
+    expect(screen.queryByText('Dashboard page')).toBeNull();
+  });
+
+  it('redirects to /dashboard when the user is already authenticated', () => {
+    mockUseAuth.mockReturnValue({
+      state: {
+        isAuthenticated: true,
+        token: 'tok',
+        expiresAt: '2099-01-01T00:00:00Z',
+      },
+      login: vi.fn(),
+      logout: vi.fn(),
+    });
+
+    renderWithRoutes('/login');
+
+    expect(screen.getByText('Dashboard page')).toBeInTheDocument();
+    expect(screen.queryByText('Login page')).toBeNull();
+  });
+});

--- a/src/features/auth/components/PublicRoute.tsx
+++ b/src/features/auth/components/PublicRoute.tsx
@@ -1,0 +1,20 @@
+import { Navigate, Outlet } from 'react-router';
+
+import { useAuth } from '../useAuth';
+
+/**
+ * Wraps routes that should only be accessible to unauthenticated users
+ * (e.g. /login).
+ *
+ * If the user is already authenticated, they are redirected to /dashboard —
+ * there is no reason to show the login page to someone who is already logged in.
+ */
+export function PublicRoute(): React.ReactElement {
+  const { state } = useAuth();
+
+  if (state.isAuthenticated) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,4 +1,6 @@
 export { AuthProvider } from './AuthProvider';
+export { ProtectedRoute } from './components/ProtectedRoute';
+export { PublicRoute } from './components/PublicRoute';
 export { clearToken, getToken, saveToken } from './tokenService';
 export type { AuthContextValue, AuthState, AuthToken } from './types';
 export { useAuth } from './useAuth';


### PR DESCRIPTION
## Summary
- `ProtectedRoute` redirects unauthenticated users to `/login`; renders outlet for authenticated users
- `PublicRoute` redirects authenticated users to `/dashboard`; renders outlet for unauthenticated users
- All internal routes in `App.tsx` are now wrapped with `ProtectedRoute`; `/login` is guarded by `PublicRoute`
- `App.test.tsx` updated to include `AuthProvider` wrapper (required by the new route guards)

Closes #68 | Part of M1: Auth Foundation

## Test plan
- [x] `pnpm ci` passes (lint + type-check + test:coverage + build)
- [x] `/project:verify-issue` verdict: PASS
- [x] `/project:review` verdict: PASS
- [x] Accessibility: N/A — no interactive elements introduced