### PR TITLE
feat(auth): add client-side logout with keyboard-accessible sign out button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ playwright-report/
 test-results/
 blob-report/
 
+# Storybook build
+storybook-static/
+
 # Editor
 .vscode/
 .idea/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+# Build artifacts
+dist/
+storybook-static/
+coverage/
+
+# Generated files
+node_modules/

--- a/e2e/logout.spec.ts
+++ b/e2e/logout.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsTestUser } from './helpers/auth';
+
+test.describe('Logout', () => {
+  test('happy path: login → access protected route → logout → redirected to /login', async ({
+    page,
+  }) => {
+    await loginAsTestUser(page);
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    await page.getByRole('button', { name: /sign out/i }).click();
+
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole('heading', { name: /sign in/i })).toBeVisible();
+  });
+
+  test('after logout, navigating to a protected route redirects to /login', async ({
+    page,
+  }) => {
+    await loginAsTestUser(page);
+
+    await page.getByRole('button', { name: /sign out/i }).click();
+    await expect(page).toHaveURL(/\/login/);
+
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('after logout, the browser back button does not re-authenticate', async ({
+    page,
+  }) => {
+    await loginAsTestUser(page);
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    await page.getByRole('button', { name: /sign out/i }).click();
+    await expect(page).toHaveURL(/\/login/);
+
+    await page.goBack();
+    // The back button may briefly show the previous URL, but ProtectedRoute
+    // immediately redirects to /login since the token is gone from storage.
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/src/shared/components/AppLayout/AppLayout.test.tsx
+++ b/src/shared/components/AppLayout/AppLayout.test.tsx
@@ -1,9 +1,20 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAuth } from '@/features/auth/useAuth';
 
 import { AppLayout } from './AppLayout';
+
+// vi.mock is hoisted by Vitest above all imports, so the mock is in place before
+// the module under test runs. The static import of useAuth above reflects the mocked module.
+vi.mock('@/features/auth/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+const mockLogout = vi.fn();
+const mockUseAuth = vi.mocked(useAuth);
 
 function renderWithRouter(ui?: React.ReactElement) {
   return render(
@@ -15,12 +26,26 @@ function renderWithRouter(ui?: React.ReactElement) {
             element={ui ?? <div data-testid="page-content">Page Content</div>}
           />
         </Route>
+        <Route path="/login" element={<div>Login Page</div>} />
       </Routes>
     </MemoryRouter>,
   );
 }
 
 describe('AppLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      state: {
+        isAuthenticated: true,
+        token: 'tok',
+        expiresAt: '2099-01-01T00:00:00Z',
+      },
+      login: vi.fn(),
+      logout: mockLogout,
+    });
+  });
+
   // --- Structure ---
 
   it('renders a sidebar and main content area', () => {
@@ -115,5 +140,40 @@ describe('AppLayout', () => {
     renderWithRouter();
     const sidebar = screen.getByRole('complementary', { name: /sidebar/i });
     expect(sidebar.className).toMatch(/overflow-y-auto/);
+  });
+
+  // --- Logout ---
+
+  describe('logout button', () => {
+    it('renders a Sign out button in the sidebar', () => {
+      renderWithRouter();
+      expect(
+        screen.getByRole('button', { name: /sign out/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('calls logout when the Sign out button is clicked', async () => {
+      const user = userEvent.setup();
+      renderWithRouter();
+      await user.click(screen.getByRole('button', { name: /sign out/i }));
+      expect(mockLogout).toHaveBeenCalledOnce();
+    });
+
+    it('navigates to /login after logout', async () => {
+      const user = userEvent.setup();
+      renderWithRouter();
+      await user.click(screen.getByRole('button', { name: /sign out/i }));
+      expect(screen.getByText('Login Page')).toBeInTheDocument();
+    });
+
+    it('is keyboard-accessible — activatable with Enter', async () => {
+      const user = userEvent.setup();
+      renderWithRouter();
+      const logoutButton = screen.getByRole('button', { name: /sign out/i });
+      logoutButton.focus();
+      expect(logoutButton).toHaveFocus();
+      await user.keyboard('{Enter}');
+      expect(mockLogout).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/src/shared/components/AppLayout/AppLayout.tsx
+++ b/src/shared/components/AppLayout/AppLayout.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Outlet } from 'react-router';
+import { Outlet, useNavigate } from 'react-router';
 
+import { useAuth } from '@/features/auth/useAuth';
+import { Button } from '@/shared/components/Button';
 import { Icon } from '@/shared/components/Icon';
 import { SidebarNav } from '@/shared/components/SidebarNav';
 import { Text } from '@/shared/components/Text';
@@ -24,6 +26,17 @@ import { cn } from '@/shared/utils/cn';
 
 export function AppLayout(): React.ReactElement {
   const [isMobileOpen, setIsMobileOpen] = useState(false);
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+
+  // useCallback keeps the reference stable. The handler calls logout (which
+  // clears the token from localStorage and resets auth state) then navigates
+  // to /login. ProtectedRoute will catch any subsequent attempt to reach a
+  // protected page and redirect here again — so the redirect is belt-and-suspenders.
+  const handleLogout = useCallback((): void => {
+    logout();
+    void navigate('/login');
+  }, [logout, navigate]);
 
   const closeMobile = useCallback(() => {
     setIsMobileOpen(false);
@@ -92,6 +105,18 @@ export function AppLayout(): React.ReactElement {
 
         {/* Sidebar navigation */}
         <SidebarNav onNavigate={closeMobile} />
+
+        {/* Sidebar footer — sign out action */}
+        <div className="mt-auto px-4 pb-2 pt-4">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleLogout}
+            className="w-full justify-start"
+          >
+            Sign out
+          </Button>
+        </div>
       </aside>
 
       {/* Main content area */}


### PR DESCRIPTION
## Summary
- Adds a **Sign out** button to the `AppLayout` sidebar footer, visible on every protected page
- On click: clears the token from localStorage via `useAuth().logout()` and navigates to `/login`
- `ProtectedRoute` prevents re-entry once the token is cleared (belt-and-suspenders redirect)
- Adds `.prettierignore` and `.gitignore` entry for `storybook-static/` build artifacts

## Test plan
- [ ] `pnpm lint && pnpm type-check && pnpm test:coverage && pnpm build && pnpm build-storybook` — all pass
- [ ] `/project:verify-issue` verdict: **PASS** — all 5 acceptance criteria covered
- [ ] `/project:review` verdict: **PASS** — all 9 categories pass
- [ ] Accessibility: Sign out is a native `<button>` with text content label, keyboard-activatable via Enter/Space
- [ ] E2E spec covers: login → dashboard → logout → /login redirect → navigate to /dashboard → redirected again → back button stays on /login

🤖 Generated with [Claude Code](https://claude.com/claude-code)