### PR TITLE
chore(tooling): fix ESLint/Prettier conflict on import/order newlines-between

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -475,9 +475,9 @@ export function formatMoney(cents: number, currency: CurrencyCode): string {
 
 ## Environment Variables
 
-| Variable       | Description                                               | Default |
-| -------------- | --------------------------------------------------------- | ------- |
-| `VITE_API_URL` | Backend base URL — leave empty in dev (proxy handles it)  | `""`    |
+| Variable       | Description                                              | Default |
+| -------------- | -------------------------------------------------------- | ------- |
+| `VITE_API_URL` | Backend base URL — leave empty in dev (proxy handles it) | `""`    |
 
 **Local development:** do not set `VITE_API_URL`. The Vite dev server proxies `/auth`, `/api`, and `/health` to `https://pfm-go-api.fly.dev` server-side, so no CORS headers are needed and no remote origin is sent from the browser.
 

--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -1,16 +1,22 @@
 import { expect, test } from '@playwright/test';
 
-import { loginAsTestUser, TEST_EMAIL, TEST_PASSWORD } from './helpers/auth';
+import { TEST_EMAIL, TEST_PASSWORD, loginAsTestUser } from './helpers/auth';
 
 test.describe('Login page', () => {
-  test('happy path: valid credentials redirect to /dashboard', async ({ page }) => {
+  test('happy path: valid credentials redirect to /dashboard', async ({
+    page,
+  }) => {
     await loginAsTestUser(page);
 
     await expect(page).toHaveURL(/\/dashboard/);
-    await expect(page.getByRole('heading', { name: /dashboard/i })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /dashboard/i }),
+    ).toBeVisible();
   });
 
-  test('shows an inline error on invalid credentials (401)', async ({ page }) => {
+  test('shows an inline error on invalid credentials (401)', async ({
+    page,
+  }) => {
     await page.goto('/login');
 
     await page.getByLabel(/email/i).fill(TEST_EMAIL);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -87,7 +87,7 @@ export default tseslint.config(
             },
           ],
           pathGroupsExcludedImportTypes: ['builtin'],
-          'newlines-between': 'always',
+          'newlines-between': 'ignore',
           alphabetize: { order: 'asc', caseInsensitive: true },
         },
       ],

--- a/src/features/auth/api/login.test.ts
+++ b/src/features/auth/api/login.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { callLogin, LoginError } from './login';
+import { LoginError, callLogin } from './login';
 
 // Spy on the global fetch so no real network calls are made.
 const mockFetch = vi.fn();
@@ -19,7 +19,11 @@ describe('callLogin', () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       status: 200,
-      json: () => Promise.resolve({ token: 'tok-abc', expires_at: '2099-01-01T00:00:00Z' }),
+      json: () =>
+        Promise.resolve({
+          token: 'tok-abc',
+          expires_at: '2099-01-01T00:00:00Z',
+        }),
     });
 
     const result = await callLogin('user@example.com', 'secret');
@@ -34,7 +38,11 @@ describe('callLogin', () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       status: 200,
-      json: () => Promise.resolve({ token: 'tok-xyz', expires_at: '2030-06-15T08:00:00Z' }),
+      json: () =>
+        Promise.resolve({
+          token: 'tok-xyz',
+          expires_at: '2030-06-15T08:00:00Z',
+        }),
     });
 
     const { expiresAt } = await callLogin('a@b.com', 'pw');
@@ -49,7 +57,9 @@ describe('callLogin', () => {
       json: () => Promise.resolve({ message: 'invalid credentials' }),
     });
 
-    const error = await callLogin('bad@example.com', 'wrong').catch((e: unknown) => e);
+    const error = await callLogin('bad@example.com', 'wrong').catch(
+      (e: unknown) => e,
+    );
     expect(error).toBeInstanceOf(LoginError);
     expect((error as LoginError).status).toBe(401);
   });
@@ -78,7 +88,8 @@ describe('callLogin', () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       status: 200,
-      json: () => Promise.resolve({ token: 'tok', expires_at: '2099-01-01T00:00:00Z' }),
+      json: () =>
+        Promise.resolve({ token: 'tok', expires_at: '2099-01-01T00:00:00Z' }),
     });
 
     await callLogin('user@example.com', 'mypassword');

--- a/src/features/auth/api/login.ts
+++ b/src/features/auth/api/login.ts
@@ -50,7 +50,10 @@ export async function callLogin(
     }
 
     // The backend uses snake_case; map to camelCase for the rest of the app.
-    const data = (await response.json()) as { token: string; expires_at: string };
+    const data = (await response.json()) as {
+      token: string;
+      expires_at: string;
+    };
     return { token: data.token, expiresAt: data.expires_at };
   } catch (error) {
     if (error instanceof LoginError) throw error;

--- a/src/features/auth/components/ProtectedRoute.test.tsx
+++ b/src/features/auth/components/ProtectedRoute.test.tsx
@@ -3,7 +3,6 @@ import { MemoryRouter, Route, Routes } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
 
 import { useAuth } from '../useAuth';
-
 import { ProtectedRoute } from './ProtectedRoute';
 
 // Mock useAuth so tests control auth state without a real provider or localStorage.

--- a/src/features/auth/components/PublicRoute.test.tsx
+++ b/src/features/auth/components/PublicRoute.test.tsx
@@ -3,7 +3,6 @@ import { MemoryRouter, Route, Routes } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
 
 import { useAuth } from '../useAuth';
-
 import { PublicRoute } from './PublicRoute';
 
 // vi.mock is hoisted above all imports at runtime by Vitest.

--- a/src/features/auth/hooks/useLoginForm.test.ts
+++ b/src/features/auth/hooks/useLoginForm.test.ts
@@ -2,9 +2,8 @@ import { act, renderHook } from '@testing-library/react';
 import { type NavigateFunction, useNavigate } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { callLogin, LoginError } from '../api/login';
+import { LoginError, callLogin } from '../api/login';
 import { useAuth } from '../useAuth';
-
 import { useLoginForm } from './useLoginForm';
 
 // Mock all external dependencies so the hook is tested in isolation.
@@ -121,7 +120,9 @@ describe('useLoginForm', () => {
       });
 
       expect(mockLogin).toHaveBeenCalledWith('tok-abc', '2099-01-01T00:00:00Z');
-      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true });
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', {
+        replace: true,
+      });
       expect(result.current.error).toBeNull();
     });
 
@@ -158,7 +159,9 @@ describe('useLoginForm', () => {
 
   describe('handleSubmit — errors', () => {
     it('sets an "invalid credentials" error on 401', async () => {
-      vi.mocked(callLogin).mockRejectedValueOnce(new LoginError(401, 'invalid'));
+      vi.mocked(callLogin).mockRejectedValueOnce(
+        new LoginError(401, 'invalid'),
+      );
 
       const { result } = renderHook(() => useLoginForm());
 
@@ -176,7 +179,9 @@ describe('useLoginForm', () => {
     });
 
     it('sets a generic error on non-401 LoginError', async () => {
-      vi.mocked(callLogin).mockRejectedValueOnce(new LoginError(500, 'server error'));
+      vi.mocked(callLogin).mockRejectedValueOnce(
+        new LoginError(500, 'server error'),
+      );
 
       const { result } = renderHook(() => useLoginForm());
 
@@ -194,7 +199,9 @@ describe('useLoginForm', () => {
     });
 
     it('sets isLoading to false after an error', async () => {
-      vi.mocked(callLogin).mockRejectedValueOnce(new LoginError(401, 'invalid'));
+      vi.mocked(callLogin).mockRejectedValueOnce(
+        new LoginError(401, 'invalid'),
+      );
 
       const { result } = renderHook(() => useLoginForm());
 

--- a/src/features/auth/hooks/useLoginForm.ts
+++ b/src/features/auth/hooks/useLoginForm.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router';
 
-import { callLogin, LoginError } from '../api/login';
+import { LoginError, callLogin } from '../api/login';
 import { useAuth } from '../useAuth';
 
 interface LoginFormState {
@@ -43,25 +43,51 @@ export function useLoginForm(): UseLoginFormReturn {
   });
 
   const handleEmailChange = (value: string): void => {
-    setState((prev) => ({ ...prev, email: value, emailError: null, error: null }));
+    setState((prev) => ({
+      ...prev,
+      email: value,
+      emailError: null,
+      error: null,
+    }));
   };
 
   const handlePasswordChange = (value: string): void => {
-    setState((prev) => ({ ...prev, password: value, passwordError: null, error: null }));
+    setState((prev) => ({
+      ...prev,
+      password: value,
+      passwordError: null,
+      error: null,
+    }));
   };
 
   const handleSubmit = async (): Promise<void> => {
     // Client-side validation — prevents unnecessary API calls.
     if (!state.email.trim()) {
-      setState((prev) => ({ ...prev, emailError: 'Email is required.', passwordError: null, error: null }));
+      setState((prev) => ({
+        ...prev,
+        emailError: 'Email is required.',
+        passwordError: null,
+        error: null,
+      }));
       return;
     }
     if (!state.password) {
-      setState((prev) => ({ ...prev, passwordError: 'Password is required.', emailError: null, error: null }));
+      setState((prev) => ({
+        ...prev,
+        passwordError: 'Password is required.',
+        emailError: null,
+        error: null,
+      }));
       return;
     }
 
-    setState((prev) => ({ ...prev, isLoading: true, emailError: null, passwordError: null, error: null }));
+    setState((prev) => ({
+      ...prev,
+      isLoading: true,
+      emailError: null,
+      passwordError: null,
+      error: null,
+    }));
 
     try {
       const { token, expiresAt } = await callLogin(state.email, state.password);

--- a/src/pages/LoginPage.test.tsx
+++ b/src/pages/LoginPage.test.tsx
@@ -39,7 +39,9 @@ describe('LoginPage', () => {
 
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /sign in/i }),
+    ).toBeInTheDocument();
   });
 
   it('calls handleEmailChange when the user types in the email field', async () => {
@@ -130,7 +132,10 @@ describe('LoginPage', () => {
     // The Input component renders the error inside the label group, associated
     // via aria-describedby — getByText finds it without needing a role query.
     expect(screen.getByText('Email is required.')).toBeInTheDocument();
-    expect(screen.getByLabelText(/email/i)).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByLabelText(/email/i)).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
   });
 
   it('password field shows its inline error when passwordError is set', () => {
@@ -141,7 +146,10 @@ describe('LoginPage', () => {
     render(<LoginPage />);
 
     expect(screen.getByText('Password is required.')).toBeInTheDocument();
-    expect(screen.getByLabelText(/password/i)).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByLabelText(/password/i)).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
   });
 
   it('password field has type="password" so characters are masked', () => {
@@ -149,7 +157,10 @@ describe('LoginPage', () => {
 
     render(<LoginPage />);
 
-    expect(screen.getByLabelText(/password/i)).toHaveAttribute('type', 'password');
+    expect(screen.getByLabelText(/password/i)).toHaveAttribute(
+      'type',
+      'password',
+    );
   });
 
   it('all form fields and button are keyboard-accessible', () => {
@@ -161,6 +172,8 @@ describe('LoginPage', () => {
     // and getByRole with a name matcher (both fail if ARIA is broken).
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /sign in/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -45,7 +45,9 @@ export function LoginPage(): React.ReactElement {
             type="email"
             autoComplete="email"
             value={email}
-            onChange={(e) => { handleEmailChange(e.target.value); }}
+            onChange={(e) => {
+              handleEmailChange(e.target.value);
+            }}
             disabled={isLoading}
             hasError={emailError !== null}
             {...(emailError !== null && { errorMessage: emailError })}
@@ -56,7 +58,9 @@ export function LoginPage(): React.ReactElement {
             type="password"
             autoComplete="current-password"
             value={password}
-            onChange={(e) => { handlePasswordChange(e.target.value); }}
+            onChange={(e) => {
+              handlePasswordChange(e.target.value);
+            }}
             disabled={isLoading}
             hasError={passwordError !== null}
             {...(passwordError !== null && { errorMessage: passwordError })}


### PR DESCRIPTION
## Summary
- Changes `newlines-between` from `'always'` to `'ignore'` in the `import/order` ESLint rule — Prettier becomes the sole authority on blank lines between import groups; group *ordering* is still enforced
- Reformats the 10 affected files so `pnpm format:check` exits 0 cleanly

## Root cause
`eslint-config-prettier` disables formatting rules that conflict with Prettier, but does **not** cover `import/order`'s `newlines-between` option. This caused ESLint `--fix` and Prettier to fight each other on blank lines between `parent` and `sibling` import groups.

## Test plan
- [ ] `pnpm lint` exits 0 (zero warnings)
- [ ] `pnpm format:check` exits 0
- [ ] `pnpm type-check` exits 0
- [ ] `pnpm test:coverage` exits 0 (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)